### PR TITLE
New event entry/exit properties

### DIFF
--- a/3.0/sportsml-specific-soccer.xsd
+++ b/3.0/sportsml-specific-soccer.xsd
@@ -109,19 +109,7 @@ applies to this specification.
 			<xs:documentation>Player statistics that are specific to soccer. | Soccer specific statistic information about a player.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="baseSoccerStatsComplexType">
-				<xs:attribute name="time-entered-event" type="xs:integer" use="optional">
-					<xs:annotation>
-						<xs:documentation>Time in minutes when the player entered the
-							event.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-				<xs:attribute name="time-exited-event" type="xs:integer" use="optional">
-					<xs:annotation>
-						<xs:documentation>Time in minutes when the player exited the event.</xs:documentation>
-					</xs:annotation>
-				</xs:attribute>
-			</xs:extension>
+			<xs:extension base="baseSoccerStatsComplexType"/>
 		</xs:complexContent>
 	</xs:complexType>
 	

--- a/3.0/sportsml.xsd
+++ b/3.0/sportsml.xsd
@@ -1946,6 +1946,26 @@ Removed unused components from the plugins
                         <xs:documentation>Number of sports-events the player has played in since the start of the event.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="date-time-entered" type="xs:dateTime" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Exact universal time player entered event. For example, the time a downhill skiier began a run.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="date-time-exited" type="xs:dateTime" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Exact universal time player exited event. For example, the time a downhill skiier finished a run.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="event-time-entered" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Time player entered event expressed as conventional game-clock time. For example, the game minute a soccer player was subbed on to the field.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="event-time-exited" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Time player exited event expressed as conventional game-clock time. For example, the game minute a soccer player was subbed off the field.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>


### PR DESCRIPTION
- removed @time-entered-event and @time-exited-event from soccer schema
- added four new general time properties to core: @date-time-entered, @date-time-exited, @event-time-entered and @event-time-exited