### PR TITLE
Fix qcodes in examples - fixes issue #50

### DIFF
--- a/3.0/examples/amfoot-match-classic-generic.xml
+++ b/3.0/examples/amfoot-match-classic-generic.xml
@@ -35,8 +35,8 @@
     <team id="l.nfl.com-t.4">
       <team-metadata key="vendteam:l.nfl.com-t.4" alignment="away">
         <name role="nrol:full">New England Patriots</name>
-        <name part="nprt:common">New England</name>
-        <name part="nprt:nickname">Patriots</name>
+        <name role="nrol:short">New England</name>
+        <name role="nrol:alternate">Patriots</name>
       </team-metadata>
       <team-stats>
         <stats>
@@ -731,8 +731,8 @@
     <team id="l.nfl.com-t.16">
       <team-metadata key="vendteam:l.nfl.com-t.16" alignment="home">
         <name role="nrol:full">Seattle Seahawks</name>
-        <name part="nprt:common">Seattle</name>
-        <name part="nprt:nickname">Seahawks</name>
+        <name role="nrol:short">Seattle</name>
+        <name role="nrol:alternate">Seahawks</name>
       </team-metadata>
       <team-stats>
         <stats>

--- a/3.0/examples/amfoot-match-classic-specific.xml
+++ b/3.0/examples/amfoot-match-classic-specific.xml
@@ -50,8 +50,8 @@
         <team id="l.nfl.com-t.4">
             <team-metadata key="vendteam:l.nfl.com-t.4" alignment="away">
                 <name role="nrol:full">New England Patriots</name>
-                <name part="nprt:common">New England</name>
-                <name part="nprt:nickname">Patriots</name>
+                <name role="nrol:short">New England</name>
+                <name role="nrol:alternate">Patriots</name>
             </team-metadata>
             <team-stats time-of-possession="33:46" score="28" score-opposing="24"
                 event-outcome="speventoutcome:win">
@@ -631,8 +631,8 @@
         <team id="l.nfl.com-t.16">
             <team-metadata key="vendteam:l.nfl.com-t.16" alignment="home">
                 <name role="nrol:full">Seattle Seahawks</name>
-                <name part="nprt:common">Seattle</name>
-                <name part="nprt:nickname">Seahawks</name>
+                <name role="nrol:short">Seattle</name>
+                <name role="nrol:alternate">Seahawks</name>
             </team-metadata>
             <team-stats time-of-possession="26:14" score="24" score-opposing="28"
                 event-outcome="speventoutcome:loss">

--- a/3.0/examples/amfoot-match-g2-generic.xml
+++ b/3.0/examples/amfoot-match-g2-generic.xml
@@ -74,8 +74,8 @@
           <team id="l.nfl.com-t.4">
             <team-metadata key="vendteam:l.nfl.com-t.4" alignment="away">
               <name role="nrol:full">New England Patriots</name>
-              <name part="nprt:common">New England</name>
-              <name part="nprt:nickname">Patriots</name>
+              <name role="nrol:short">New England</name>
+              <name role="nrol:alternate">Patriots</name>
             </team-metadata>
             <team-stats>
               <stats>
@@ -770,8 +770,8 @@
           <team id="l.nfl.com-t.16">
             <team-metadata key="vendteam:l.nfl.com-t.16" alignment="home">
               <name role="nrol:full">Seattle Seahawks</name>
-              <name part="nprt:common">Seattle</name>
-              <name part="nprt:nickname">Seahawks</name>
+              <name role="nrol:short">Seattle</name>
+              <name role="nrol:alternate">Seahawks</name>
             </team-metadata>
             <team-stats>
               <stats>

--- a/3.0/examples/amfoot-match-g2-specific.xml
+++ b/3.0/examples/amfoot-match-g2-specific.xml
@@ -82,8 +82,8 @@
                     <team id="l.nfl.com-t.4">
                         <team-metadata key="vendteam:l.nfl.com-t.4" alignment="away">
                             <name role="nrol:full">New England Patriots</name>
-                            <name part="nprt:common">New England</name>
-                            <name part="nprt:nickname">Patriots</name>
+                            <name role="nrol:short">New England</name>
+                            <name role="nrol:alternate">Patriots</name>
                         </team-metadata>
                         <team-stats time-of-possession="33:46" score="28" score-opposing="24"
                             event-outcome="speventoutcome:win">
@@ -703,8 +703,8 @@
                     <team id="l.nfl.com-t.16">
                         <team-metadata key="vendteam:l.nfl.com-t.16" alignment="home">
                             <name role="nrol:full">Seattle Seahawks</name>
-                            <name part="nprt:common">Seattle</name>
-                            <name part="nprt:nickname">Seahawks</name>
+                            <name role="nrol:short">Seattle</name>
+                            <name role="nrol:alternate">Seahawks</name>
                         </team-metadata>
                         <team-stats time-of-possession="26:14" score="24" score-opposing="28"
                             event-outcome="speventoutcome:loss">

--- a/3.0/examples/baseball-match-classic-generic.xml
+++ b/3.0/examples/baseball-match-classic-generic.xml
@@ -39,8 +39,8 @@
         <team id="l.mlb.com-t.16">
             <team-metadata key="vendteam:l.mlb.com-t.16" alignment="away">
                 <name role="nrol:full">Miami Marlins</name>
-                <name part="nprt:common">Miami</name>
-                <name part="nprt:nickname">Marlins</name>
+                <name role="nrol:short">Miami</name>
+                <name role="nrol:alternate">Marlins</name>
             </team-metadata>
             <team-stats>
                 <stats>
@@ -927,8 +927,8 @@
         <team id="l.mlb.com-t.27">
             <team-metadata key="vendteam:l.mlb.com-t.27" alignment="home">
                 <name role="nrol:full">Colorado Rockies</name>
-                <name part="nprt:common">Colorado</name>
-                <name part="nprt:nickname">Rockies</name>
+                <name role="nrol:short">Colorado</name>
+                <name role="nrol:alternate">Rockies</name>
             </team-metadata>
             <team-stats>
                 <stats>

--- a/3.0/examples/baseball-match-classic-specific.xml
+++ b/3.0/examples/baseball-match-classic-specific.xml
@@ -39,8 +39,8 @@
         <team id="l.mlb.com-t.16">
             <team-metadata key="vendteam:l.mlb.com-t.16" alignment="away">
                 <name role="nrol:full">Miami Marlins</name>
-                <name part="nprt:common">Miami</name>
-                <name part="nprt:nickname">Marlins</name>
+                <name role="nrol:short">Miami</name>
+                <name role="nrol:alternate">Marlins</name>
             </team-metadata>
             <team-stats event-outcome="speventoutcome:undecided" score="6" score-opposing="1">
                 <sub-score period-value="1" score="0"/>
@@ -474,8 +474,8 @@
         <team id="l.mlb.com-t.27">
             <team-metadata key="vendteam:l.mlb.com-t.27" alignment="home">
                 <name role="nrol:full">Colorado Rockies</name>
-                <name part="nprt:common">Colorado</name>
-                <name part="nprt:nickname">Rockies</name>
+                <name role="nrol:short">Colorado</name>
+                <name role="nrol:alternate">Rockies</name>
             </team-metadata>
             <team-stats event-outcome="speventoutcome:undecided" score="1" score-opposing="6">
                 <sub-score period-value="1" score="0"/>

--- a/3.0/examples/baseball-match-g2-generic.xml
+++ b/3.0/examples/baseball-match-g2-generic.xml
@@ -75,8 +75,8 @@
                     <team id="l.mlb.com-t.16"> 
                         <team-metadata key="vendteam:l.mlb.com-t.16" alignment="away">
                             <name role="nrol:full">Miami Marlins</name>
-                            <name part="nprt:common">Miami</name>
-                            <name part="nprt:nickname">Marlins</name>
+                            <name role="nrol:short">Miami</name>
+                            <name role="nrol:alternate">Marlins</name>
                         </team-metadata>
                         <team-stats>
                             <stats>
@@ -1251,8 +1251,8 @@
                     <team id="l.mlb.com-t.27">
                         <team-metadata key="vendteam:l.mlb.com-t.27" alignment="home">
                             <name role="nrol:full">Colorado Rockies</name>
-                            <name part="nprt:common">Colorado</name>
-                            <name part="nprt:nickname">Rockies</name>
+                            <name role="nrol:short">Colorado</name>
+                            <name role="nrol:alternate">Rockies</name>
                         </team-metadata>
                         <team-stats>
                             <stats>

--- a/3.0/examples/baseball-match-g2-specific.xml
+++ b/3.0/examples/baseball-match-g2-specific.xml
@@ -75,8 +75,8 @@
                     <team id="l.mlb.com-t.16">
                         <team-metadata key="vendteam:l.mlb.com-t.16" alignment="away">
                             <name role="nrol:full">Miami Marlins</name>
-                            <name part="nprt:common">Miami</name>
-                            <name part="nprt:nickname">Marlins</name>
+                            <name role="nrol:short">Miami</name>
+                            <name role="nrol:alternate">Marlins</name>
                         </team-metadata>
                         <team-stats event-outcome="speventoutcome:undecided" score="6"
                             score-opposing="1">
@@ -561,8 +561,8 @@
                     <team id="l.mlb.com-t.27">
                         <team-metadata key="vendteam:l.mlb.com-t.27" alignment="home">
                             <name role="nrol:full">Colorado Rockies</name>
-                            <name part="nprt:common">Colorado</name>
-                            <name part="nprt:nickname">Rockies</name>
+                            <name role="nrol:short">Colorado</name>
+                            <name role="nrol:alternate">Rockies</name>
                         </team-metadata>
                         <team-stats event-outcome="speventoutcome:undecided" score="1"
                             score-opposing="6">

--- a/3.0/examples/basketball-match-classic-generic.xml
+++ b/3.0/examples/basketball-match-classic-generic.xml
@@ -37,8 +37,8 @@
         <team id="l.nba.com-t.14">
             <team-metadata key="vendteam:l.nba.com-t.14" alignment="away">
                 <name role="nrol:full">Milwaukee Bucks</name>
-                <name part="nprt:common">Milwaukee</name>
-                <name part="nprt:nickname">Bucks</name>
+                <name role="nrol:short">Milwaukee</name>
+                <name role="nrol:alternate">Bucks</name>
             </team-metadata>
             <team-stats>
                 <stats>
@@ -386,8 +386,8 @@
         <team id="l.nba.com-t.17">
             <team-metadata key="vendteam:l.nba.com-t.17" alignment="home">
                 <name role="nrol:full">Denver Nuggets</name>
-                <name part="nprt:common">Denver</name>
-                <name part="nprt:nickname">Nuggets</name>
+                <name role="nrol:short">Denver</name>
+                <name role="nrol:alternate">Nuggets</name>
             </team-metadata>
             <team-stats>
                 <stats>

--- a/3.0/examples/basketball-match-classic-specific.xml
+++ b/3.0/examples/basketball-match-classic-specific.xml
@@ -37,8 +37,8 @@
         <team id="l.nba.com-t.14">
             <team-metadata key="vendteam:l.nba.com-t.14" alignment="away">
                 <name role="nrol:full">Milwaukee Bucks</name>
-                <name part="nprt:common">Milwaukee</name>
-                <name part="nprt:nickname">Bucks</name>
+                <name role="nrol:short">Milwaukee</name>
+                <name role="nrol:alternate">Bucks</name>
             </team-metadata>
             <team-stats event-outcome="speventoutcome:undecided" score="84" score-opposing="93">
                 <penalty-stats count="0" type="team technical fouls"/>
@@ -252,8 +252,8 @@
         <team id="l.nba.com-t.17">
             <team-metadata key="vendteam:l.nba.com-t.17" alignment="home">
                 <name role="nrol:full">Denver Nuggets</name>
-                <name part="nprt:common">Denver</name>
-                <name part="nprt:nickname">Nuggets</name>
+                <name role="nrol:short">Denver</name>
+                <name role="nrol:alternate">Nuggets</name>
             </team-metadata>
             <team-stats event-outcome="speventoutcome:undecided" score="93" score-opposing="84">
                 <penalty-stats count="2" type="team technical fouls"/>

--- a/3.0/examples/basketball-match-g2-generic.xml
+++ b/3.0/examples/basketball-match-g2-generic.xml
@@ -71,8 +71,8 @@
                     <team id="l.nba.com-t.14">
                         <team-metadata key="vendteam:l.nba.com-t.14" alignment="away">
                             <name role="nrol:full">Milwaukee Bucks</name>
-                            <name part="nprt:common">Milwaukee</name>
-                            <name part="nprt:nickname">Bucks</name>
+                            <name role="nrol:short">Milwaukee</name>
+                            <name role="nrol:alternate">Bucks</name>
                         </team-metadata>
                         <team-stats>
                             <stats>
@@ -509,8 +509,8 @@
                     <team id="l.nba.com-t.17">
                         <team-metadata key="vendteam:l.nba.com-t.17" alignment="home">
                             <name role="nrol:full">Denver Nuggets</name>
-                            <name part="nprt:common">Denver</name>
-                            <name part="nprt:nickname">Nuggets</name>
+                            <name role="nrol:short">Denver</name>
+                            <name role="nrol:alternate">Nuggets</name>
                         </team-metadata>
                         <team-stats>
                             <stats>

--- a/3.0/examples/basketball-match-g2-specific.xml
+++ b/3.0/examples/basketball-match-g2-specific.xml
@@ -71,8 +71,8 @@
                     <team id="l.nba.com-t.14">
                         <team-metadata key="vendteam:l.nba.com-t.14" alignment="away">
                             <name role="nrol:full">Milwaukee Bucks</name>
-                            <name part="nprt:common">Milwaukee</name>
-                            <name part="nprt:nickname">Bucks</name>
+                            <name role="nrol:short">Milwaukee</name>
+                            <name role="nrol:alternate">Bucks</name>
                         </team-metadata>
                         <team-stats event-outcome="speventoutcome:undecided" score="84"
                             score-opposing="93">
@@ -309,8 +309,8 @@
                     <team id="l.nba.com-t.17">
                         <team-metadata key="vendteam:l.nba.com-t.17" alignment="home">
                             <name role="nrol:full">Denver Nuggets</name>
-                            <name part="nprt:common">Denver</name>
-                            <name part="nprt:nickname">Nuggets</name>
+                            <name role="nrol:short">Denver</name>
+                            <name role="nrol:alternate">Nuggets</name>
                         </team-metadata>
                         <team-stats event-outcome="speventoutcome:undecided" score="93"
                             score-opposing="84">

--- a/3.0/examples/biathlon_mixedrelay_g2.xml
+++ b/3.0/examples/biathlon_mixedrelay_g2.xml
@@ -56,8 +56,8 @@
                         <player>
                             <player-metadata team-idref="BIB6" nationality="France" gender="female"
                                 uniform-number="6-1">
-                                <name part="nprt:first">Anais</name>
-                                <name part="nprt:last">Bescond</name>
+                                <name part="nprt:given">Anais</name>
+                                <name part="nprt:family">Bescond</name>
                             </player-metadata>
                             <player-stats score="18.20,6">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -69,8 +69,8 @@
                         <player>
                             <player-metadata team-idref="BIB6" nationality="France" gender="female"
                                 uniform-number="6-2">
-                                <name part="nprt:first">Anais</name>
-                                <name part="nprt:last">Chevalier</name>
+                                <name part="nprt:given">Anais</name>
+                                <name part="nprt:family">Chevalier</name>
                             </player-metadata>
                             <player-stats score="19.26,8">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -82,8 +82,8 @@
                         <player>
                             <player-metadata team-idref="BIB6" nationality="France" gender="male"
                                 uniform-number="6-3">
-                                <name part="nprt:first">Simon</name>
-                                <name part="nprt:last">Fourcade</name>
+                                <name part="nprt:given">Simon</name>
+                                <name part="nprt:family">Fourcade</name>
                             </player-metadata>
                             <player-stats score="19.13,2">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -95,8 +95,8 @@
                         <player>
                             <player-metadata team-idref="BIB6" nationality="France" gender="male"
                                 uniform-number="6-4">
-                                <name part="nprt:first">Martin</name>
-                                <name part="nprt:last">Fourcade</name>
+                                <name part="nprt:given">Martin</name>
+                                <name part="nprt:family">Fourcade</name>
                             </player-metadata>
                             <player-stats score="18.05,5">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -122,8 +122,8 @@
                         <player>
                             <player-metadata team-idref="BIB2" nationality="Norway" gender="female"
                                 uniform-number="2-1">
-                                <name part="nprt:first">Synnoeve</name>
-                                <name part="nprt:last">Solemdal</name>
+                                <name part="nprt:given">Synnoeve</name>
+                                <name part="nprt:family">Solemdal</name>
                             </player-metadata>
                             <player-stats score="19.39,0">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -135,8 +135,8 @@
                         <player>
                             <player-metadata team-idref="BIB2" nationality="Norway" gender="female"
                                 uniform-number="2-2">
-                                <name part="nprt:first">Tiril</name>
-                                <name part="nprt:last">Eckhoff</name>
+                                <name part="nprt:given">Tiril</name>
+                                <name part="nprt:family">Eckhoff</name>
                             </player-metadata>
                             <player-stats score="18.27,2">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -148,8 +148,8 @@
                         <player>
                             <player-metadata team-idref="BIB2" nationality="Norway" gender="male"
                                 uniform-number="2-3">
-                                <name part="nprt:first">Vetle Sjastad</name>
-                                <name part="nprt:last">Christiansen</name>
+                                <name part="nprt:given">Vetle Sjastad</name>
+                                <name part="nprt:family">Christiansen</name>
                             </player-metadata>
                             <player-stats score="18.46,3">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>
@@ -161,8 +161,8 @@
                         <player>
                             <player-metadata team-idref="BIB2" nationality="Norway" gender="male"
                                 uniform-number="2-4">
-                                <name part="nprt:first">Lars Helge</name>
-                                <name part="nprt:last">Birkeland</name>
+                                <name part="nprt:given">Lars Helge</name>
+                                <name part="nprt:family">Birkeland</name>
                             </player-metadata>
                             <player-stats score="18.57,2">
                                 <sub-score period-value="1" score="0" sub-score-name="Penaltyrounds"/>

--- a/3.0/examples/golf-tour.xml
+++ b/3.0/examples/golf-tour.xml
@@ -58,8 +58,8 @@
 
                             <player>
                                 <player-metadata>
-                                    <name part="nprt:first">Jhonattan</name>
-                                    <name part="nprt:last">Vegas</name>
+                                    <name part="nprt:given">Jhonattan</name>
+                                    <name part="nprt:family">Vegas</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name/></locality><area><name/></area><country><name>Venezuela</name></country><postalCode/></address>

--- a/3.0/examples/ice-hockey-match-classic-generic.xml
+++ b/3.0/examples/ice-hockey-match-classic-generic.xml
@@ -39,8 +39,8 @@
         <team id="l.nhl.com-t.10">
             <team-metadata key="vendteam:l.nhl.com-t.10" alignment="home">
                 <name role="nrol:full">Toronto Maple Leafs</name>
-                <name part="nprt:common">Toronto</name>
-                <name part="nprt:nickname">Maple Leafs</name>
+                <name role="nrol:short">Toronto</name>
+                <name role="nrol:alternate">Maple Leafs</name>
             </team-metadata>
             <team-stats>
                 <stats temporal-unit-type="sptemporalunit:event">
@@ -1401,8 +1401,8 @@
         <team id="l.nhl.com-t.8">
             <team-metadata key="vendteam:l.nhl.com-t.8" alignment="away">
                 <name role="nrol:full">Montreal Canadiens</name>
-                <name part="nprt:common">Montreal</name>
-                <name part="nprt:nickname">Canadiens</name>
+                <name role="nrol:short">Montreal</name>
+                <name role="nrol:alternate">Canadiens</name>
             </team-metadata>
             <team-stats>
                 <stats temporal-unit-type="sptemporalunit:event">

--- a/3.0/examples/ice-hockey-match-classic-specific.xml
+++ b/3.0/examples/ice-hockey-match-classic-specific.xml
@@ -39,8 +39,8 @@
         <team id="l.nhl.com-t.10">
             <team-metadata key="vendteam:l.nhl.com-t.10" alignment="home">
                 <name role="nrol:full">Toronto Maple Leafs</name>
-                <name part="nprt:common">Toronto</name>
-                <name part="nprt:nickname">Maple Leafs</name>
+                <name role="nrol:short">Toronto</name>
+                <name role="nrol:alternate">Maple Leafs</name>
             </team-metadata>
             <team-stats temporal-unit-type="sptemporalunit:event"
                 temporal-unit-value="vendor:l.nhl.com-2015-e.20001" score="1" score-attempts="37"
@@ -641,8 +641,8 @@
         <team id="l.nhl.com-t.8">
             <team-metadata key="vendteam:l.nhl.com-t.8" alignment="away">
                 <name role="nrol:full">Montreal Canadiens</name>
-                <name part="nprt:common">Montreal</name>
-                <name part="nprt:nickname">Canadiens</name>
+                <name role="nrol:short">Montreal</name>
+                <name role="nrol:alternate">Canadiens</name>
             </team-metadata>
             <team-stats temporal-unit-type="sptemporalunit:event"
                 temporal-unit-value="vendor:l.nhl.com-2015-e.20001" score="3" score-attempts="30"

--- a/3.0/examples/ice-hockey-match-g2-generic.xml
+++ b/3.0/examples/ice-hockey-match-g2-generic.xml
@@ -73,8 +73,8 @@
                     <team id="l.nhl.com-t.10">
                         <team-metadata key="vendteam:l.nhl.com-t.10" alignment="home">
                             <name role="nrol:full">Toronto Maple Leafs</name>
-                            <name part="nprt:common">Toronto</name>
-                            <name part="nprt:nickname">Maple Leafs</name>
+                            <name role="nrol:short">Toronto</name>
+                            <name role="nrol:alternate">Maple Leafs</name>
                         </team-metadata>
                         <team-stats>
                             <stats temporal-unit-type="sptemporalunit:event">
@@ -1514,8 +1514,8 @@
                     <team id="l.nhl.com-t.8">
                         <team-metadata key="vendteam:l.nhl.com-t.8" alignment="away">
                             <name role="nrol:full">Montreal Canadiens</name>
-                            <name part="nprt:common">Montreal</name>
-                            <name part="nprt:nickname">Canadiens</name>
+                            <name role="nrol:short">Montreal</name>
+                            <name role="nrol:alternate">Canadiens</name>
                         </team-metadata>
                         <team-stats>
                             <stats temporal-unit-type="sptemporalunit:event">

--- a/3.0/examples/ice-hockey-match-g2-specific.xml
+++ b/3.0/examples/ice-hockey-match-g2-specific.xml
@@ -74,8 +74,8 @@
                     <team id="l.nhl.com-t.10">
                         <team-metadata key="vendteam:l.nhl.com-t.10" alignment="home">
                             <name role="nrol:full">Toronto Maple Leafs</name>
-                            <name part="nprt:common">Toronto</name>
-                            <name part="nprt:nickname">Maple Leafs</name>
+                            <name role="nrol:short">Toronto</name>
+                            <name role="nrol:alternate">Maple Leafs</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="sptemporalunit:event"
                             temporal-unit-value="vendor:l.nhl.com-2015-e.20001" score="1"
@@ -716,8 +716,8 @@
                     <team id="l.nhl.com-t.8">
                         <team-metadata key="vendteam:l.nhl.com-t.8" alignment="away">
                             <name role="nrol:full">Montreal Canadiens</name>
-                            <name part="nprt:common">Montreal</name>
-                            <name part="nprt:nickname">Canadiens</name>
+                            <name role="nrol:short">Montreal</name>
+                            <name role="nrol:alternate">Canadiens</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="sptemporalunit:event"
                             temporal-unit-value="vendor:l.nhl.com-2015-e.20001" score="3"

--- a/3.0/examples/ice-hockey-plays-classic-generic.xml
+++ b/3.0/examples/ice-hockey-plays-classic-generic.xml
@@ -32,8 +32,8 @@
         <team id="l.nhl.com-t.3">
             <team-metadata key="vendteam:l.nhl.com-t.3" alignment="home">
                 <name role="nrol:full">NY Rangers</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Rangers</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Rangers</name>
             </team-metadata>
             <team-stats>
                 <stats temporal-unit-type="sptemporalunit:event">
@@ -213,8 +213,8 @@
         <team id="l.nhl.com-t.15">
             <team-metadata key="vendteam:l.nhl.com-t.15" alignment="away">
                 <name role="nrol:full">Washington Capitals</name>
-                <name part="nprt:common">Washington</name>
-                <name part="nprt:nickname">Capitals</name>
+                <name role="nrol:short">Washington</name>
+                <name role="nrol:alternate">Capitals</name>
             </team-metadata>
             <team-stats>
                 <stats temporal-unit-type="sptemporalunit:event">

--- a/3.0/examples/ice-hockey-plays-classic-specific.xml
+++ b/3.0/examples/ice-hockey-plays-classic-specific.xml
@@ -32,8 +32,8 @@
         <team id="l.nhl.com-t.3">
             <team-metadata key="vendteam:l.nhl.com-t.3" alignment="home">
                 <name role="nrol:full">NY Rangers</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Rangers</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Rangers</name>
             </team-metadata>
             <team-stats temporal-unit-type="sptemporalunit:event"
                 temporal-unit-value="vendor:l.nhl.com-2014-e.30227" score="" score-attempts=""/>
@@ -209,8 +209,8 @@
         <team id="l.nhl.com-t.15">
             <team-metadata key="vendteam:l.nhl.com-t.15" alignment="away">
                 <name role="nrol:full">Washington Capitals</name>
-                <name part="nprt:common">Washington</name>
-                <name part="nprt:nickname">Capitals</name>
+                <name role="nrol:short">Washington</name>
+                <name role="nrol:alternate">Capitals</name>
             </team-metadata>
             <team-stats temporal-unit-type="sptemporalunit:event"
                 temporal-unit-value="vendor:l.nhl.com-2014-e.30227" score="" score-attempts=""/>

--- a/3.0/examples/ice-hockey-plays-g2-generic.xml
+++ b/3.0/examples/ice-hockey-plays-g2-generic.xml
@@ -64,8 +64,8 @@
                     <team id="l.nhl.com-t.3">
                         <team-metadata key="vendteam:l.nhl.com-t.3" alignment="home">
                             <name role="nrol:full">NY Rangers</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Rangers</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Rangers</name>
                         </team-metadata>
                         <team-stats>
                             <stats temporal-unit-type="sptemporalunit:event">
@@ -245,8 +245,8 @@
                     <team id="l.nhl.com-t.15">
                         <team-metadata key="vendteam:l.nhl.com-t.15" alignment="away">
                             <name role="nrol:full">Washington Capitals</name>
-                            <name part="nprt:common">Washington</name>
-                            <name part="nprt:nickname">Capitals</name>
+                            <name role="nrol:short">Washington</name>
+                            <name role="nrol:alternate">Capitals</name>
                         </team-metadata>
                         <team-stats>
                             <stats temporal-unit-type="sptemporalunit:event">

--- a/3.0/examples/ice-hockey-plays-g2-specific.xml
+++ b/3.0/examples/ice-hockey-plays-g2-specific.xml
@@ -64,8 +64,8 @@
                     <team id="l.nhl.com-t.3">
                         <team-metadata key="vendteam:l.nhl.com-t.3" alignment="home">
                             <name role="nrol:full">NY Rangers</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Rangers</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Rangers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="sptemporalunit:event"
                             temporal-unit-value="vendor:l.nhl.com-2014-e.30227" score=""
@@ -242,8 +242,8 @@
                     <team id="l.nhl.com-t.15">
                         <team-metadata key="vendteam:l.nhl.com-t.15" alignment="away">
                             <name role="nrol:full">Washington Capitals</name>
-                            <name part="nprt:common">Washington</name>
-                            <name part="nprt:nickname">Capitals</name>
+                            <name role="nrol:short">Washington</name>
+                            <name role="nrol:alternate">Capitals</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="sptemporalunit:event"
                             temporal-unit-value="vendor:l.nhl.com-2014-e.30227" score=""

--- a/3.0/examples/ice-hockey-roster-classic.xml
+++ b/3.0/examples/ice-hockey-roster-classic.xml
@@ -29,8 +29,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.21">
                 <name role="nrol:full">Dallas Stars</name>
-                <name part="nprt:common">Dallas</name>
-                <name part="nprt:nickname">Stars</name>
+                <name role="nrol:short">Dallas</name>
+                <name role="nrol:alternate">Stars</name>
             </team-metadata>
             <player id="l.nhl.com-p.5099">
                 <player-metadata key="vendperson:l.nhl.com-p.5099" uniform-number=""

--- a/3.0/examples/ice-hockey-roster-g2.xml
+++ b/3.0/examples/ice-hockey-roster-g2.xml
@@ -58,8 +58,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.21">
                             <name role="nrol:full">Dallas Stars</name>
-                            <name part="nprt:common">Dallas</name>
-                            <name part="nprt:nickname">Stars</name>
+                            <name role="nrol:short">Dallas</name>
+                            <name role="nrol:alternate">Stars</name>
                         </team-metadata>
                         <player id="l.nhl.com-p.5099">
                             <player-metadata key="vendperson:l.nhl.com-p.5099" uniform-number=""

--- a/3.0/examples/ice-hockey-standings-classic-generic.xml
+++ b/3.0/examples/ice-hockey-standings-classic-generic.xml
@@ -34,8 +34,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.24">
                 <name role="nrol:full">San Jose Sharks</name>
-                <name part="nprt:common">San Jose</name>
-                <name part="nprt:nickname">Sharks</name>
+                <name role="nrol:short">San Jose</name>
+                <name role="nrol:alternate">Sharks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -48,8 +48,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.28">
                 <name role="nrol:full">Calgary Flames</name>
-                <name part="nprt:common">Calgary</name>
-                <name part="nprt:nickname">Flames</name>
+                <name role="nrol:short">Calgary</name>
+                <name role="nrol:alternate">Flames</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -62,8 +62,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.25">
                 <name role="nrol:full">Arizona Coyotes</name>
-                <name part="nprt:common">Arizona</name>
-                <name part="nprt:nickname">Coyotes</name>
+                <name role="nrol:short">Arizona</name>
+                <name role="nrol:alternate">Coyotes</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -76,8 +76,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.22">
                 <name role="nrol:full">Anaheim Ducks</name>
-                <name part="nprt:common">Anaheim</name>
-                <name part="nprt:nickname">Ducks</name>
+                <name role="nrol:short">Anaheim</name>
+                <name role="nrol:alternate">Ducks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -90,8 +90,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.23">
                 <name role="nrol:full">Los Angeles Kings</name>
-                <name part="nprt:common">Los Angeles</name>
-                <name part="nprt:nickname">Kings</name>
+                <name role="nrol:short">Los Angeles</name>
+                <name role="nrol:alternate">Kings</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -104,8 +104,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.29">
                 <name role="nrol:full">Edmonton Oilers</name>
-                <name part="nprt:common">Edmonton</name>
-                <name part="nprt:nickname">Oilers</name>
+                <name role="nrol:short">Edmonton</name>
+                <name role="nrol:alternate">Oilers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -118,8 +118,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.26">
                 <name role="nrol:full">Vancouver Canucks</name>
-                <name part="nprt:common">Vancouver</name>
-                <name part="nprt:nickname">Canucks</name>
+                <name role="nrol:short">Vancouver</name>
+                <name role="nrol:alternate">Canucks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -144,8 +144,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.24">
                 <name role="nrol:full">San Jose Sharks</name>
-                <name part="nprt:common">San Jose</name>
-                <name part="nprt:nickname">Sharks</name>
+                <name role="nrol:short">San Jose</name>
+                <name role="nrol:alternate">Sharks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -182,8 +182,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.28">
                 <name role="nrol:full">Calgary Flames</name>
-                <name part="nprt:common">Calgary</name>
-                <name part="nprt:nickname">Flames</name>
+                <name role="nrol:short">Calgary</name>
+                <name role="nrol:alternate">Flames</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -220,8 +220,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.25">
                 <name role="nrol:full">Arizona Coyotes</name>
-                <name part="nprt:common">Arizona</name>
-                <name part="nprt:nickname">Coyotes</name>
+                <name role="nrol:short">Arizona</name>
+                <name role="nrol:alternate">Coyotes</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -258,8 +258,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.22">
                 <name role="nrol:full">Anaheim Ducks</name>
-                <name part="nprt:common">Anaheim</name>
-                <name part="nprt:nickname">Ducks</name>
+                <name role="nrol:short">Anaheim</name>
+                <name role="nrol:alternate">Ducks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -292,8 +292,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.23">
                 <name role="nrol:full">Los Angeles Kings</name>
-                <name part="nprt:common">Los Angeles</name>
-                <name part="nprt:nickname">Kings</name>
+                <name role="nrol:short">Los Angeles</name>
+                <name role="nrol:alternate">Kings</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -327,8 +327,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.29">
                 <name role="nrol:full">Edmonton Oilers</name>
-                <name part="nprt:common">Edmonton</name>
-                <name part="nprt:nickname">Oilers</name>
+                <name role="nrol:short">Edmonton</name>
+                <name role="nrol:alternate">Oilers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -358,8 +358,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.26">
                 <name role="nrol:full">Vancouver Canucks</name>
-                <name part="nprt:common">Vancouver</name>
-                <name part="nprt:nickname">Canucks</name>
+                <name role="nrol:short">Vancouver</name>
+                <name role="nrol:alternate">Canucks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -408,8 +408,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.18">
                 <name role="nrol:full">St. Louis Blues</name>
-                <name part="nprt:common">St. Louis</name>
-                <name part="nprt:nickname">Blues</name>
+                <name role="nrol:short">St. Louis</name>
+                <name role="nrol:alternate">Blues</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -422,8 +422,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.21">
                 <name role="nrol:full">Dallas Stars</name>
-                <name part="nprt:common">Dallas</name>
-                <name part="nprt:nickname">Stars</name>
+                <name role="nrol:short">Dallas</name>
+                <name role="nrol:alternate">Stars</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -436,8 +436,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.27">
                 <name role="nrol:full">Colorado Avalanche</name>
-                <name part="nprt:common">Colorado</name>
-                <name part="nprt:nickname">Avalanche</name>
+                <name role="nrol:short">Colorado</name>
+                <name role="nrol:alternate">Avalanche</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -452,8 +452,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.16">
                 <name role="nrol:full">Chicago Blackhawks</name>
-                <name part="nprt:common">Chicago</name>
-                <name part="nprt:nickname">Blackhawks</name>
+                <name role="nrol:short">Chicago</name>
+                <name role="nrol:alternate">Blackhawks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -466,8 +466,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.19">
                 <name role="nrol:full">Nashville Predators</name>
-                <name part="nprt:common">Nashville</name>
-                <name part="nprt:nickname">Predators</name>
+                <name role="nrol:short">Nashville</name>
+                <name role="nrol:alternate">Predators</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -480,8 +480,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.30">
                 <name role="nrol:full">Minnesota Wild</name>
-                <name part="nprt:common">Minnesota</name>
-                <name part="nprt:nickname">Wild</name>
+                <name role="nrol:short">Minnesota</name>
+                <name role="nrol:alternate">Wild</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -494,8 +494,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.9">
                 <name role="nrol:full">Winnipeg Jets</name>
-                <name part="nprt:common">Winnipeg</name>
-                <name part="nprt:nickname">Jets</name>
+                <name role="nrol:short">Winnipeg</name>
+                <name role="nrol:alternate">Jets</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -520,8 +520,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.18">
                 <name role="nrol:full">St. Louis Blues</name>
-                <name part="nprt:common">St. Louis</name>
-                <name part="nprt:nickname">Blues</name>
+                <name role="nrol:short">St. Louis</name>
+                <name role="nrol:alternate">Blues</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -558,8 +558,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.21">
                 <name role="nrol:full">Dallas Stars</name>
-                <name part="nprt:common">Dallas</name>
-                <name part="nprt:nickname">Stars</name>
+                <name role="nrol:short">Dallas</name>
+                <name role="nrol:alternate">Stars</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -596,8 +596,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.27">
                 <name role="nrol:full">Colorado Avalanche</name>
-                <name part="nprt:common">Colorado</name>
-                <name part="nprt:nickname">Avalanche</name>
+                <name role="nrol:short">Colorado</name>
+                <name role="nrol:alternate">Avalanche</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -631,8 +631,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.16">
                 <name role="nrol:full">Chicago Blackhawks</name>
-                <name part="nprt:common">Chicago</name>
-                <name part="nprt:nickname">Blackhawks</name>
+                <name role="nrol:short">Chicago</name>
+                <name role="nrol:alternate">Blackhawks</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -661,8 +661,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.19">
                 <name role="nrol:full">Nashville Predators</name>
-                <name part="nprt:common">Nashville</name>
-                <name part="nprt:nickname">Predators</name>
+                <name role="nrol:short">Nashville</name>
+                <name role="nrol:alternate">Predators</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -692,8 +692,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.30">
                 <name role="nrol:full">Minnesota Wild</name>
-                <name part="nprt:common">Minnesota</name>
-                <name part="nprt:nickname">Wild</name>
+                <name role="nrol:short">Minnesota</name>
+                <name role="nrol:alternate">Wild</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -730,8 +730,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.9">
                 <name role="nrol:full">Winnipeg Jets</name>
-                <name part="nprt:common">Winnipeg</name>
-                <name part="nprt:nickname">Jets</name>
+                <name role="nrol:short">Winnipeg</name>
+                <name role="nrol:alternate">Jets</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -769,8 +769,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.20">
                 <name role="nrol:full">Columbus Blue Jackets</name>
-                <name part="nprt:common">Columbus</name>
-                <name part="nprt:nickname">Blue Jackets</name>
+                <name role="nrol:short">Columbus</name>
+                <name role="nrol:alternate">Blue Jackets</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -785,8 +785,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.5">
                 <name role="nrol:full">Pittsburgh Penguins</name>
-                <name part="nprt:common">Pittsburgh</name>
-                <name part="nprt:nickname">Penguins</name>
+                <name role="nrol:short">Pittsburgh</name>
+                <name role="nrol:alternate">Penguins</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -799,8 +799,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.6">
                 <name role="nrol:full">Carolina Hurricanes</name>
-                <name part="nprt:common">Carolina</name>
-                <name part="nprt:nickname">Hurricanes</name>
+                <name role="nrol:short">Carolina</name>
+                <name role="nrol:alternate">Hurricanes</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -813,8 +813,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.4">
                 <name role="nrol:full">Philadelphia Flyers</name>
-                <name part="nprt:common">Philadelphia</name>
-                <name part="nprt:nickname">Flyers</name>
+                <name role="nrol:short">Philadelphia</name>
+                <name role="nrol:alternate">Flyers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -829,8 +829,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.2">
                 <name role="nrol:full">New York Islanders</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Islanders</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Islanders</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -843,8 +843,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.3">
                 <name role="nrol:full">New York Rangers</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Rangers</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Rangers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -859,8 +859,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.1">
                 <name role="nrol:full">New Jersey Devils</name>
-                <name part="nprt:common">New Jersey</name>
-                <name part="nprt:nickname">Devils</name>
+                <name role="nrol:short">New Jersey</name>
+                <name role="nrol:alternate">Devils</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -873,8 +873,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.8">
                 <name role="nrol:full">Washington Capitals</name>
-                <name part="nprt:common">Washington</name>
-                <name part="nprt:nickname">Capitals</name>
+                <name role="nrol:short">Washington</name>
+                <name role="nrol:alternate">Capitals</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -901,8 +901,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.20">
                 <name role="nrol:full">Columbus Blue Jackets</name>
-                <name part="nprt:common">Columbus</name>
-                <name part="nprt:nickname">Blue Jackets</name>
+                <name role="nrol:short">Columbus</name>
+                <name role="nrol:alternate">Blue Jackets</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -939,8 +939,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.5">
                 <name role="nrol:full">Pittsburgh Penguins</name>
-                <name part="nprt:common">Pittsburgh</name>
-                <name part="nprt:nickname">Penguins</name>
+                <name role="nrol:short">Pittsburgh</name>
+                <name role="nrol:alternate">Penguins</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -966,8 +966,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.6">
                 <name role="nrol:full">Carolina Hurricanes</name>
-                <name part="nprt:common">Carolina</name>
-                <name part="nprt:nickname">Hurricanes</name>
+                <name role="nrol:short">Carolina</name>
+                <name role="nrol:alternate">Hurricanes</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1000,8 +1000,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.4">
                 <name role="nrol:full">Philadelphia Flyers</name>
-                <name part="nprt:common">Philadelphia</name>
-                <name part="nprt:nickname">Flyers</name>
+                <name role="nrol:short">Philadelphia</name>
+                <name role="nrol:alternate">Flyers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1031,8 +1031,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.2">
                 <name role="nrol:full">New York Islanders</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Islanders</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Islanders</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1061,8 +1061,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.3">
                 <name role="nrol:full">New York Rangers</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Rangers</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Rangers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1099,8 +1099,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.1">
                 <name role="nrol:full">New Jersey Devils</name>
-                <name part="nprt:common">New Jersey</name>
-                <name part="nprt:nickname">Devils</name>
+                <name role="nrol:short">New Jersey</name>
+                <name role="nrol:alternate">Devils</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1137,8 +1137,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.8">
                 <name role="nrol:full">Washington Capitals</name>
-                <name part="nprt:common">Washington</name>
-                <name part="nprt:nickname">Capitals</name>
+                <name role="nrol:short">Washington</name>
+                <name role="nrol:alternate">Capitals</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1184,8 +1184,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.7">
                 <name role="nrol:full">Tampa Bay Lightning</name>
-                <name part="nprt:common">Tampa Bay</name>
-                <name part="nprt:nickname">Lightning</name>
+                <name role="nrol:short">Tampa Bay</name>
+                <name role="nrol:alternate">Lightning</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1198,8 +1198,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.14">
                 <name role="nrol:full">Ottawa Senators</name>
-                <name part="nprt:common">Ottawa</name>
-                <name part="nprt:nickname">Senators</name>
+                <name role="nrol:short">Ottawa</name>
+                <name role="nrol:alternate">Senators</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1212,8 +1212,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.12">
                 <name role="nrol:full">Buffalo Sabres</name>
-                <name part="nprt:common">Buffalo</name>
-                <name part="nprt:nickname">Sabres</name>
+                <name role="nrol:short">Buffalo</name>
+                <name role="nrol:alternate">Sabres</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1226,8 +1226,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.11">
                 <name role="nrol:full">Boston Bruins</name>
-                <name part="nprt:common">Boston</name>
-                <name part="nprt:nickname">Bruins</name>
+                <name role="nrol:short">Boston</name>
+                <name role="nrol:alternate">Bruins</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1242,8 +1242,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.13">
                 <name role="nrol:full">Montreal Canadiens</name>
-                <name part="nprt:common">Montreal</name>
-                <name part="nprt:nickname">Canadiens</name>
+                <name role="nrol:short">Montreal</name>
+                <name role="nrol:alternate">Canadiens</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1258,8 +1258,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.10">
                 <name role="nrol:full">Florida Panthers</name>
-                <name part="nprt:common">Florida</name>
-                <name part="nprt:nickname">Panthers</name>
+                <name role="nrol:short">Florida</name>
+                <name role="nrol:alternate">Panthers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1272,8 +1272,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.15">
                 <name role="nrol:full">Toronto Maple Leafs</name>
-                <name part="nprt:common">Toronto</name>
-                <name part="nprt:nickname">Maple Leafs</name>
+                <name role="nrol:short">Toronto</name>
+                <name role="nrol:alternate">Maple Leafs</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1286,8 +1286,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.17">
                 <name role="nrol:full">Detroit Red Wings</name>
-                <name part="nprt:common">Detroit</name>
-                <name part="nprt:nickname">Red Wings</name>
+                <name role="nrol:short">Detroit</name>
+                <name role="nrol:alternate">Red Wings</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals competition="spct:league"
@@ -1312,8 +1312,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.7">
                 <name role="nrol:full">Tampa Bay Lightning</name>
-                <name part="nprt:common">Tampa Bay</name>
-                <name part="nprt:nickname">Lightning</name>
+                <name role="nrol:short">Tampa Bay</name>
+                <name role="nrol:alternate">Lightning</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1350,8 +1350,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.14">
                 <name role="nrol:full">Ottawa Senators</name>
-                <name part="nprt:common">Ottawa</name>
-                <name part="nprt:nickname">Senators</name>
+                <name role="nrol:short">Ottawa</name>
+                <name role="nrol:alternate">Senators</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1388,8 +1388,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.12">
                 <name role="nrol:full">Buffalo Sabres</name>
-                <name part="nprt:common">Buffalo</name>
-                <name part="nprt:nickname">Sabres</name>
+                <name role="nrol:short">Buffalo</name>
+                <name role="nrol:alternate">Sabres</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1423,8 +1423,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.11">
                 <name role="nrol:full">Boston Bruins</name>
-                <name part="nprt:common">Boston</name>
-                <name part="nprt:nickname">Bruins</name>
+                <name role="nrol:short">Boston</name>
+                <name role="nrol:alternate">Bruins</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1458,8 +1458,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.13">
                 <name role="nrol:full">Montreal Canadiens</name>
-                <name part="nprt:common">Montreal</name>
-                <name part="nprt:nickname">Canadiens</name>
+                <name role="nrol:short">Montreal</name>
+                <name role="nrol:alternate">Canadiens</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1493,8 +1493,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.10">
                 <name role="nrol:full">Florida Panthers</name>
-                <name part="nprt:common">Florida</name>
-                <name part="nprt:nickname">Panthers</name>
+                <name role="nrol:short">Florida</name>
+                <name role="nrol:alternate">Panthers</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1524,8 +1524,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.15">
                 <name role="nrol:full">Toronto Maple Leafs</name>
-                <name part="nprt:common">Toronto</name>
-                <name part="nprt:nickname">Maple Leafs</name>
+                <name role="nrol:short">Toronto</name>
+                <name role="nrol:alternate">Maple Leafs</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"
@@ -1583,8 +1583,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.17">
                 <name role="nrol:full">Detroit Red Wings</name>
-                <name part="nprt:common">Detroit</name>
-                <name part="nprt:nickname">Red Wings</name>
+                <name role="nrol:short">Detroit</name>
+                <name role="nrol:alternate">Red Wings</name>
             </team-metadata>
             <team-stats>
                 <outcome-totals unit-type="spct:division"

--- a/3.0/examples/ice-hockey-standings-classic-specific.xml
+++ b/3.0/examples/ice-hockey-standings-classic-specific.xml
@@ -34,8 +34,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.24">
                 <name role="nrol:full">San Jose Sharks</name>
-                <name part="nprt:common">San Jose</name>
-                <name part="nprt:nickname">Sharks</name>
+                <name role="nrol:short">San Jose</name>
+                <name role="nrol:alternate">Sharks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -48,8 +48,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.28">
                 <name role="nrol:full">Calgary Flames</name>
-                <name part="nprt:common">Calgary</name>
-                <name part="nprt:nickname">Flames</name>
+                <name role="nrol:short">Calgary</name>
+                <name role="nrol:alternate">Flames</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -62,8 +62,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.25">
                 <name role="nrol:full">Arizona Coyotes</name>
-                <name part="nprt:common">Arizona</name>
-                <name part="nprt:nickname">Coyotes</name>
+                <name role="nrol:short">Arizona</name>
+                <name role="nrol:alternate">Coyotes</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -76,8 +76,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.22">
                 <name role="nrol:full">Anaheim Ducks</name>
-                <name part="nprt:common">Anaheim</name>
-                <name part="nprt:nickname">Ducks</name>
+                <name role="nrol:short">Anaheim</name>
+                <name role="nrol:alternate">Ducks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -90,8 +90,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.23">
                 <name role="nrol:full">Los Angeles Kings</name>
-                <name part="nprt:common">Los Angeles</name>
-                <name part="nprt:nickname">Kings</name>
+                <name role="nrol:short">Los Angeles</name>
+                <name role="nrol:alternate">Kings</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -104,8 +104,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.29">
                 <name role="nrol:full">Edmonton Oilers</name>
-                <name part="nprt:common">Edmonton</name>
-                <name part="nprt:nickname">Oilers</name>
+                <name role="nrol:short">Edmonton</name>
+                <name role="nrol:alternate">Oilers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -118,8 +118,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.26">
                 <name role="nrol:full">Vancouver Canucks</name>
-                <name part="nprt:common">Vancouver</name>
-                <name part="nprt:nickname">Canucks</name>
+                <name role="nrol:short">Vancouver</name>
+                <name role="nrol:alternate">Canucks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -144,8 +144,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.24">
                 <name role="nrol:full">San Jose Sharks</name>
-                <name part="nprt:common">San Jose</name>
-                <name part="nprt:nickname">Sharks</name>
+                <name role="nrol:short">San Jose</name>
+                <name role="nrol:alternate">Sharks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -182,8 +182,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.28">
                 <name role="nrol:full">Calgary Flames</name>
-                <name part="nprt:common">Calgary</name>
-                <name part="nprt:nickname">Flames</name>
+                <name role="nrol:short">Calgary</name>
+                <name role="nrol:alternate">Flames</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -220,8 +220,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.25">
                 <name role="nrol:full">Arizona Coyotes</name>
-                <name part="nprt:common">Arizona</name>
-                <name part="nprt:nickname">Coyotes</name>
+                <name role="nrol:short">Arizona</name>
+                <name role="nrol:alternate">Coyotes</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -258,8 +258,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.22">
                 <name role="nrol:full">Anaheim Ducks</name>
-                <name part="nprt:common">Anaheim</name>
-                <name part="nprt:nickname">Ducks</name>
+                <name role="nrol:short">Anaheim</name>
+                <name role="nrol:alternate">Ducks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -292,8 +292,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.23">
                 <name role="nrol:full">Los Angeles Kings</name>
-                <name part="nprt:common">Los Angeles</name>
-                <name part="nprt:nickname">Kings</name>
+                <name role="nrol:short">Los Angeles</name>
+                <name role="nrol:alternate">Kings</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -327,8 +327,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.29">
                 <name role="nrol:full">Edmonton Oilers</name>
-                <name part="nprt:common">Edmonton</name>
-                <name part="nprt:nickname">Oilers</name>
+                <name role="nrol:short">Edmonton</name>
+                <name role="nrol:alternate">Oilers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -358,8 +358,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.26">
                 <name role="nrol:full">Vancouver Canucks</name>
-                <name part="nprt:common">Vancouver</name>
-                <name part="nprt:nickname">Canucks</name>
+                <name role="nrol:short">Vancouver</name>
+                <name role="nrol:alternate">Canucks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -408,8 +408,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.18">
                 <name role="nrol:full">St. Louis Blues</name>
-                <name part="nprt:common">St. Louis</name>
-                <name part="nprt:nickname">Blues</name>
+                <name role="nrol:short">St. Louis</name>
+                <name role="nrol:alternate">Blues</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -422,8 +422,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.21">
                 <name role="nrol:full">Dallas Stars</name>
-                <name part="nprt:common">Dallas</name>
-                <name part="nprt:nickname">Stars</name>
+                <name role="nrol:short">Dallas</name>
+                <name role="nrol:alternate">Stars</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -436,8 +436,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.27">
                 <name role="nrol:full">Colorado Avalanche</name>
-                <name part="nprt:common">Colorado</name>
-                <name part="nprt:nickname">Avalanche</name>
+                <name role="nrol:short">Colorado</name>
+                <name role="nrol:alternate">Avalanche</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -452,8 +452,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.16">
                 <name role="nrol:full">Chicago Blackhawks</name>
-                <name part="nprt:common">Chicago</name>
-                <name part="nprt:nickname">Blackhawks</name>
+                <name role="nrol:short">Chicago</name>
+                <name role="nrol:alternate">Blackhawks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -466,8 +466,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.19">
                 <name role="nrol:full">Nashville Predators</name>
-                <name part="nprt:common">Nashville</name>
-                <name part="nprt:nickname">Predators</name>
+                <name role="nrol:short">Nashville</name>
+                <name role="nrol:alternate">Predators</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -480,8 +480,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.30">
                 <name role="nrol:full">Minnesota Wild</name>
-                <name part="nprt:common">Minnesota</name>
-                <name part="nprt:nickname">Wild</name>
+                <name role="nrol:short">Minnesota</name>
+                <name role="nrol:alternate">Wild</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -494,8 +494,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.9">
                 <name role="nrol:full">Winnipeg Jets</name>
-                <name part="nprt:common">Winnipeg</name>
-                <name part="nprt:nickname">Jets</name>
+                <name role="nrol:short">Winnipeg</name>
+                <name role="nrol:alternate">Jets</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -520,8 +520,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.18">
                 <name role="nrol:full">St. Louis Blues</name>
-                <name part="nprt:common">St. Louis</name>
-                <name part="nprt:nickname">Blues</name>
+                <name role="nrol:short">St. Louis</name>
+                <name role="nrol:alternate">Blues</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -558,8 +558,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.21">
                 <name role="nrol:full">Dallas Stars</name>
-                <name part="nprt:common">Dallas</name>
-                <name part="nprt:nickname">Stars</name>
+                <name role="nrol:short">Dallas</name>
+                <name role="nrol:alternate">Stars</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -596,8 +596,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.27">
                 <name role="nrol:full">Colorado Avalanche</name>
-                <name part="nprt:common">Colorado</name>
-                <name part="nprt:nickname">Avalanche</name>
+                <name role="nrol:short">Colorado</name>
+                <name role="nrol:alternate">Avalanche</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -631,8 +631,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.16">
                 <name role="nrol:full">Chicago Blackhawks</name>
-                <name part="nprt:common">Chicago</name>
-                <name part="nprt:nickname">Blackhawks</name>
+                <name role="nrol:short">Chicago</name>
+                <name role="nrol:alternate">Blackhawks</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -661,8 +661,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.19">
                 <name role="nrol:full">Nashville Predators</name>
-                <name part="nprt:common">Nashville</name>
-                <name part="nprt:nickname">Predators</name>
+                <name role="nrol:short">Nashville</name>
+                <name role="nrol:alternate">Predators</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -692,8 +692,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.30">
                 <name role="nrol:full">Minnesota Wild</name>
-                <name part="nprt:common">Minnesota</name>
-                <name part="nprt:nickname">Wild</name>
+                <name role="nrol:short">Minnesota</name>
+                <name role="nrol:alternate">Wild</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -730,8 +730,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.9">
                 <name role="nrol:full">Winnipeg Jets</name>
-                <name part="nprt:common">Winnipeg</name>
-                <name part="nprt:nickname">Jets</name>
+                <name role="nrol:short">Winnipeg</name>
+                <name role="nrol:alternate">Jets</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -769,8 +769,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.20">
                 <name role="nrol:full">Columbus Blue Jackets</name>
-                <name part="nprt:common">Columbus</name>
-                <name part="nprt:nickname">Blue Jackets</name>
+                <name role="nrol:short">Columbus</name>
+                <name role="nrol:alternate">Blue Jackets</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -785,8 +785,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.5">
                 <name role="nrol:full">Pittsburgh Penguins</name>
-                <name part="nprt:common">Pittsburgh</name>
-                <name part="nprt:nickname">Penguins</name>
+                <name role="nrol:short">Pittsburgh</name>
+                <name role="nrol:alternate">Penguins</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -799,8 +799,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.6">
                 <name role="nrol:full">Carolina Hurricanes</name>
-                <name part="nprt:common">Carolina</name>
-                <name part="nprt:nickname">Hurricanes</name>
+                <name role="nrol:short">Carolina</name>
+                <name role="nrol:alternate">Hurricanes</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -813,8 +813,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.4">
                 <name role="nrol:full">Philadelphia Flyers</name>
-                <name part="nprt:common">Philadelphia</name>
-                <name part="nprt:nickname">Flyers</name>
+                <name role="nrol:short">Philadelphia</name>
+                <name role="nrol:alternate">Flyers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -829,8 +829,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.2">
                 <name role="nrol:full">New York Islanders</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Islanders</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Islanders</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -843,8 +843,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.3">
                 <name role="nrol:full">New York Rangers</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Rangers</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Rangers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -859,8 +859,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.1">
                 <name role="nrol:full">New Jersey Devils</name>
-                <name part="nprt:common">New Jersey</name>
-                <name part="nprt:nickname">Devils</name>
+                <name role="nrol:short">New Jersey</name>
+                <name role="nrol:alternate">Devils</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -873,8 +873,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.8">
                 <name role="nrol:full">Washington Capitals</name>
-                <name part="nprt:common">Washington</name>
-                <name part="nprt:nickname">Capitals</name>
+                <name role="nrol:short">Washington</name>
+                <name role="nrol:alternate">Capitals</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -901,8 +901,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.20">
                 <name role="nrol:full">Columbus Blue Jackets</name>
-                <name part="nprt:common">Columbus</name>
-                <name part="nprt:nickname">Blue Jackets</name>
+                <name role="nrol:short">Columbus</name>
+                <name role="nrol:alternate">Blue Jackets</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -939,8 +939,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.5">
                 <name role="nrol:full">Pittsburgh Penguins</name>
-                <name part="nprt:common">Pittsburgh</name>
-                <name part="nprt:nickname">Penguins</name>
+                <name role="nrol:short">Pittsburgh</name>
+                <name role="nrol:alternate">Penguins</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -966,8 +966,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.6">
                 <name role="nrol:full">Carolina Hurricanes</name>
-                <name part="nprt:common">Carolina</name>
-                <name part="nprt:nickname">Hurricanes</name>
+                <name role="nrol:short">Carolina</name>
+                <name role="nrol:alternate">Hurricanes</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1000,8 +1000,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.4">
                 <name role="nrol:full">Philadelphia Flyers</name>
-                <name part="nprt:common">Philadelphia</name>
-                <name part="nprt:nickname">Flyers</name>
+                <name role="nrol:short">Philadelphia</name>
+                <name role="nrol:alternate">Flyers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1031,8 +1031,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.2">
                 <name role="nrol:full">New York Islanders</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Islanders</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Islanders</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1061,8 +1061,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.3">
                 <name role="nrol:full">New York Rangers</name>
-                <name part="nprt:common">New York</name>
-                <name part="nprt:nickname">Rangers</name>
+                <name role="nrol:short">New York</name>
+                <name role="nrol:alternate">Rangers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1099,8 +1099,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.1">
                 <name role="nrol:full">New Jersey Devils</name>
-                <name part="nprt:common">New Jersey</name>
-                <name part="nprt:nickname">Devils</name>
+                <name role="nrol:short">New Jersey</name>
+                <name role="nrol:alternate">Devils</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1137,8 +1137,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.8">
                 <name role="nrol:full">Washington Capitals</name>
-                <name part="nprt:common">Washington</name>
-                <name part="nprt:nickname">Capitals</name>
+                <name role="nrol:short">Washington</name>
+                <name role="nrol:alternate">Capitals</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1184,8 +1184,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.7">
                 <name role="nrol:full">Tampa Bay Lightning</name>
-                <name part="nprt:common">Tampa Bay</name>
-                <name part="nprt:nickname">Lightning</name>
+                <name role="nrol:short">Tampa Bay</name>
+                <name role="nrol:alternate">Lightning</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1198,8 +1198,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.14">
                 <name role="nrol:full">Ottawa Senators</name>
-                <name part="nprt:common">Ottawa</name>
-                <name part="nprt:nickname">Senators</name>
+                <name role="nrol:short">Ottawa</name>
+                <name role="nrol:alternate">Senators</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1212,8 +1212,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.12">
                 <name role="nrol:full">Buffalo Sabres</name>
-                <name part="nprt:common">Buffalo</name>
-                <name part="nprt:nickname">Sabres</name>
+                <name role="nrol:short">Buffalo</name>
+                <name role="nrol:alternate">Sabres</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1226,8 +1226,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.11">
                 <name role="nrol:full">Boston Bruins</name>
-                <name part="nprt:common">Boston</name>
-                <name part="nprt:nickname">Bruins</name>
+                <name role="nrol:short">Boston</name>
+                <name role="nrol:alternate">Bruins</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1242,8 +1242,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.13">
                 <name role="nrol:full">Montreal Canadiens</name>
-                <name part="nprt:common">Montreal</name>
-                <name part="nprt:nickname">Canadiens</name>
+                <name role="nrol:short">Montreal</name>
+                <name role="nrol:alternate">Canadiens</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1258,8 +1258,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.10">
                 <name role="nrol:full">Florida Panthers</name>
-                <name part="nprt:common">Florida</name>
-                <name part="nprt:nickname">Panthers</name>
+                <name role="nrol:short">Florida</name>
+                <name role="nrol:alternate">Panthers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1272,8 +1272,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.15">
                 <name role="nrol:full">Toronto Maple Leafs</name>
-                <name part="nprt:common">Toronto</name>
-                <name part="nprt:nickname">Maple Leafs</name>
+                <name role="nrol:short">Toronto</name>
+                <name role="nrol:alternate">Maple Leafs</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1286,8 +1286,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.17">
                 <name role="nrol:full">Detroit Red Wings</name>
-                <name part="nprt:common">Detroit</name>
-                <name part="nprt:nickname">Red Wings</name>
+                <name role="nrol:short">Detroit</name>
+                <name role="nrol:alternate">Red Wings</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-exhibition">
                 <outcome-totals competition="spct:league"
@@ -1312,8 +1312,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.7">
                 <name role="nrol:full">Tampa Bay Lightning</name>
-                <name part="nprt:common">Tampa Bay</name>
-                <name part="nprt:nickname">Lightning</name>
+                <name role="nrol:short">Tampa Bay</name>
+                <name role="nrol:alternate">Lightning</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1350,8 +1350,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.14">
                 <name role="nrol:full">Ottawa Senators</name>
-                <name part="nprt:common">Ottawa</name>
-                <name part="nprt:nickname">Senators</name>
+                <name role="nrol:short">Ottawa</name>
+                <name role="nrol:alternate">Senators</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1388,8 +1388,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.12">
                 <name role="nrol:full">Buffalo Sabres</name>
-                <name part="nprt:common">Buffalo</name>
-                <name part="nprt:nickname">Sabres</name>
+                <name role="nrol:short">Buffalo</name>
+                <name role="nrol:alternate">Sabres</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1423,8 +1423,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.11">
                 <name role="nrol:full">Boston Bruins</name>
-                <name part="nprt:common">Boston</name>
-                <name part="nprt:nickname">Bruins</name>
+                <name role="nrol:short">Boston</name>
+                <name role="nrol:alternate">Bruins</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1458,8 +1458,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.13">
                 <name role="nrol:full">Montreal Canadiens</name>
-                <name part="nprt:common">Montreal</name>
-                <name part="nprt:nickname">Canadiens</name>
+                <name role="nrol:short">Montreal</name>
+                <name role="nrol:alternate">Canadiens</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1493,8 +1493,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.10">
                 <name role="nrol:full">Florida Panthers</name>
-                <name part="nprt:common">Florida</name>
-                <name part="nprt:nickname">Panthers</name>
+                <name role="nrol:short">Florida</name>
+                <name role="nrol:alternate">Panthers</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division" temporal-unit-type="spct:season-regular"
@@ -1524,8 +1524,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.15">
                 <name role="nrol:full">Toronto Maple Leafs</name>
-                <name part="nprt:common">Toronto</name>
-                <name part="nprt:nickname">Maple Leafs</name>
+                <name role="nrol:short">Toronto</name>
+                <name role="nrol:alternate">Maple Leafs</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"
@@ -1583,8 +1583,8 @@
         <team>
             <team-metadata key="vendteam:l.nhl.com-t.17">
                 <name role="nrol:full">Detroit Red Wings</name>
-                <name part="nprt:common">Detroit</name>
-                <name part="nprt:nickname">Red Wings</name>
+                <name role="nrol:short">Detroit</name>
+                <name role="nrol:alternate">Red Wings</name>
             </team-metadata>
             <team-stats temporal-unit-type="spct:season-regular">
                 <outcome-totals unit-type="spct:division"

--- a/3.0/examples/ice-hockey-standings-g2-generic.xml
+++ b/3.0/examples/ice-hockey-standings-g2-generic.xml
@@ -63,8 +63,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.24">
                             <name role="nrol:full">San Jose Sharks</name>
-                            <name part="nprt:common">San Jose</name>
-                            <name part="nprt:nickname">Sharks</name>
+                            <name role="nrol:short">San Jose</name>
+                            <name role="nrol:alternate">Sharks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -77,8 +77,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.28">
                             <name role="nrol:full">Calgary Flames</name>
-                            <name part="nprt:common">Calgary</name>
-                            <name part="nprt:nickname">Flames</name>
+                            <name role="nrol:short">Calgary</name>
+                            <name role="nrol:alternate">Flames</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -91,8 +91,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.25">
                             <name role="nrol:full">Arizona Coyotes</name>
-                            <name part="nprt:common">Arizona</name>
-                            <name part="nprt:nickname">Coyotes</name>
+                            <name role="nrol:short">Arizona</name>
+                            <name role="nrol:alternate">Coyotes</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -105,8 +105,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.22">
                             <name role="nrol:full">Anaheim Ducks</name>
-                            <name part="nprt:common">Anaheim</name>
-                            <name part="nprt:nickname">Ducks</name>
+                            <name role="nrol:short">Anaheim</name>
+                            <name role="nrol:alternate">Ducks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -119,8 +119,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.23">
                             <name role="nrol:full">Los Angeles Kings</name>
-                            <name part="nprt:common">Los Angeles</name>
-                            <name part="nprt:nickname">Kings</name>
+                            <name role="nrol:short">Los Angeles</name>
+                            <name role="nrol:alternate">Kings</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -133,8 +133,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.29">
                             <name role="nrol:full">Edmonton Oilers</name>
-                            <name part="nprt:common">Edmonton</name>
-                            <name part="nprt:nickname">Oilers</name>
+                            <name role="nrol:short">Edmonton</name>
+                            <name role="nrol:alternate">Oilers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -147,8 +147,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.26">
                             <name role="nrol:full">Vancouver Canucks</name>
-                            <name part="nprt:common">Vancouver</name>
-                            <name part="nprt:nickname">Canucks</name>
+                            <name role="nrol:short">Vancouver</name>
+                            <name role="nrol:alternate">Canucks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -173,8 +173,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.24">
                             <name role="nrol:full">San Jose Sharks</name>
-                            <name part="nprt:common">San Jose</name>
-                            <name part="nprt:nickname">Sharks</name>
+                            <name role="nrol:short">San Jose</name>
+                            <name role="nrol:alternate">Sharks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -217,8 +217,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.28">
                             <name role="nrol:full">Calgary Flames</name>
-                            <name part="nprt:common">Calgary</name>
-                            <name part="nprt:nickname">Flames</name>
+                            <name role="nrol:short">Calgary</name>
+                            <name role="nrol:alternate">Flames</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -261,8 +261,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.25">
                             <name role="nrol:full">Arizona Coyotes</name>
-                            <name part="nprt:common">Arizona</name>
-                            <name part="nprt:nickname">Coyotes</name>
+                            <name role="nrol:short">Arizona</name>
+                            <name role="nrol:alternate">Coyotes</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -305,8 +305,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.22">
                             <name role="nrol:full">Anaheim Ducks</name>
-                            <name part="nprt:common">Anaheim</name>
-                            <name part="nprt:nickname">Ducks</name>
+                            <name role="nrol:short">Anaheim</name>
+                            <name role="nrol:alternate">Ducks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -344,8 +344,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.23">
                             <name role="nrol:full">Los Angeles Kings</name>
-                            <name part="nprt:common">Los Angeles</name>
-                            <name part="nprt:nickname">Kings</name>
+                            <name role="nrol:short">Los Angeles</name>
+                            <name role="nrol:alternate">Kings</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -384,8 +384,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.29">
                             <name role="nrol:full">Edmonton Oilers</name>
-                            <name part="nprt:common">Edmonton</name>
-                            <name part="nprt:nickname">Oilers</name>
+                            <name role="nrol:short">Edmonton</name>
+                            <name role="nrol:alternate">Oilers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -420,8 +420,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.26">
                             <name role="nrol:full">Vancouver Canucks</name>
-                            <name part="nprt:common">Vancouver</name>
-                            <name part="nprt:nickname">Canucks</name>
+                            <name role="nrol:short">Vancouver</name>
+                            <name role="nrol:alternate">Canucks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -476,8 +476,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.18">
                             <name role="nrol:full">St. Louis Blues</name>
-                            <name part="nprt:common">St. Louis</name>
-                            <name part="nprt:nickname">Blues</name>
+                            <name role="nrol:short">St. Louis</name>
+                            <name role="nrol:alternate">Blues</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -490,8 +490,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.21">
                             <name role="nrol:full">Dallas Stars</name>
-                            <name part="nprt:common">Dallas</name>
-                            <name part="nprt:nickname">Stars</name>
+                            <name role="nrol:short">Dallas</name>
+                            <name role="nrol:alternate">Stars</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -504,8 +504,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.27">
                             <name role="nrol:full">Colorado Avalanche</name>
-                            <name part="nprt:common">Colorado</name>
-                            <name part="nprt:nickname">Avalanche</name>
+                            <name role="nrol:short">Colorado</name>
+                            <name role="nrol:alternate">Avalanche</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -521,8 +521,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.16">
                             <name role="nrol:full">Chicago Blackhawks</name>
-                            <name part="nprt:common">Chicago</name>
-                            <name part="nprt:nickname">Blackhawks</name>
+                            <name role="nrol:short">Chicago</name>
+                            <name role="nrol:alternate">Blackhawks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -535,8 +535,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.19">
                             <name role="nrol:full">Nashville Predators</name>
-                            <name part="nprt:common">Nashville</name>
-                            <name part="nprt:nickname">Predators</name>
+                            <name role="nrol:short">Nashville</name>
+                            <name role="nrol:alternate">Predators</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -549,8 +549,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.30">
                             <name role="nrol:full">Minnesota Wild</name>
-                            <name part="nprt:common">Minnesota</name>
-                            <name part="nprt:nickname">Wild</name>
+                            <name role="nrol:short">Minnesota</name>
+                            <name role="nrol:alternate">Wild</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -563,8 +563,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.9">
                             <name role="nrol:full">Winnipeg Jets</name>
-                            <name part="nprt:common">Winnipeg</name>
-                            <name part="nprt:nickname">Jets</name>
+                            <name role="nrol:short">Winnipeg</name>
+                            <name role="nrol:alternate">Jets</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -589,8 +589,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.18">
                             <name role="nrol:full">St. Louis Blues</name>
-                            <name part="nprt:common">St. Louis</name>
-                            <name part="nprt:nickname">Blues</name>
+                            <name role="nrol:short">St. Louis</name>
+                            <name role="nrol:alternate">Blues</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -633,8 +633,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.21">
                             <name role="nrol:full">Dallas Stars</name>
-                            <name part="nprt:common">Dallas</name>
-                            <name part="nprt:nickname">Stars</name>
+                            <name role="nrol:short">Dallas</name>
+                            <name role="nrol:alternate">Stars</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -677,8 +677,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.27">
                             <name role="nrol:full">Colorado Avalanche</name>
-                            <name part="nprt:common">Colorado</name>
-                            <name part="nprt:nickname">Avalanche</name>
+                            <name role="nrol:short">Colorado</name>
+                            <name role="nrol:alternate">Avalanche</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -717,8 +717,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.16">
                             <name role="nrol:full">Chicago Blackhawks</name>
-                            <name part="nprt:common">Chicago</name>
-                            <name part="nprt:nickname">Blackhawks</name>
+                            <name role="nrol:short">Chicago</name>
+                            <name role="nrol:alternate">Blackhawks</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -753,8 +753,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.19">
                             <name role="nrol:full">Nashville Predators</name>
-                            <name part="nprt:common">Nashville</name>
-                            <name part="nprt:nickname">Predators</name>
+                            <name role="nrol:short">Nashville</name>
+                            <name role="nrol:alternate">Predators</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -789,8 +789,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.30">
                             <name role="nrol:full">Minnesota Wild</name>
-                            <name part="nprt:common">Minnesota</name>
-                            <name part="nprt:nickname">Wild</name>
+                            <name role="nrol:short">Minnesota</name>
+                            <name role="nrol:alternate">Wild</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -833,8 +833,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.9">
                             <name role="nrol:full">Winnipeg Jets</name>
-                            <name part="nprt:common">Winnipeg</name>
-                            <name part="nprt:nickname">Jets</name>
+                            <name role="nrol:short">Winnipeg</name>
+                            <name role="nrol:alternate">Jets</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -877,8 +877,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.20">
                             <name role="nrol:full">Columbus Blue Jackets</name>
-                            <name part="nprt:common">Columbus</name>
-                            <name part="nprt:nickname">Blue Jackets</name>
+                            <name role="nrol:short">Columbus</name>
+                            <name role="nrol:alternate">Blue Jackets</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -894,8 +894,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.5">
                             <name role="nrol:full">Pittsburgh Penguins</name>
-                            <name part="nprt:common">Pittsburgh</name>
-                            <name part="nprt:nickname">Penguins</name>
+                            <name role="nrol:short">Pittsburgh</name>
+                            <name role="nrol:alternate">Penguins</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -908,8 +908,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.6">
                             <name role="nrol:full">Carolina Hurricanes</name>
-                            <name part="nprt:common">Carolina</name>
-                            <name part="nprt:nickname">Hurricanes</name>
+                            <name role="nrol:short">Carolina</name>
+                            <name role="nrol:alternate">Hurricanes</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -922,8 +922,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.4">
                             <name role="nrol:full">Philadelphia Flyers</name>
-                            <name part="nprt:common">Philadelphia</name>
-                            <name part="nprt:nickname">Flyers</name>
+                            <name role="nrol:short">Philadelphia</name>
+                            <name role="nrol:alternate">Flyers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -939,8 +939,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.2">
                             <name role="nrol:full">New York Islanders</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Islanders</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Islanders</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -953,8 +953,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.3">
                             <name role="nrol:full">New York Rangers</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Rangers</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Rangers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -970,8 +970,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.1">
                             <name role="nrol:full">New Jersey Devils</name>
-                            <name part="nprt:common">New Jersey</name>
-                            <name part="nprt:nickname">Devils</name>
+                            <name role="nrol:short">New Jersey</name>
+                            <name role="nrol:alternate">Devils</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -984,8 +984,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.8">
                             <name role="nrol:full">Washington Capitals</name>
-                            <name part="nprt:common">Washington</name>
-                            <name part="nprt:nickname">Capitals</name>
+                            <name role="nrol:short">Washington</name>
+                            <name role="nrol:alternate">Capitals</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1013,8 +1013,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.20">
                             <name role="nrol:full">Columbus Blue Jackets</name>
-                            <name part="nprt:common">Columbus</name>
-                            <name part="nprt:nickname">Blue Jackets</name>
+                            <name role="nrol:short">Columbus</name>
+                            <name role="nrol:alternate">Blue Jackets</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1057,8 +1057,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.5">
                             <name role="nrol:full">Pittsburgh Penguins</name>
-                            <name part="nprt:common">Pittsburgh</name>
-                            <name part="nprt:nickname">Penguins</name>
+                            <name role="nrol:short">Pittsburgh</name>
+                            <name role="nrol:alternate">Penguins</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1089,8 +1089,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.6">
                             <name role="nrol:full">Carolina Hurricanes</name>
-                            <name part="nprt:common">Carolina</name>
-                            <name part="nprt:nickname">Hurricanes</name>
+                            <name role="nrol:short">Carolina</name>
+                            <name role="nrol:alternate">Hurricanes</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1129,8 +1129,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.4">
                             <name role="nrol:full">Philadelphia Flyers</name>
-                            <name part="nprt:common">Philadelphia</name>
-                            <name part="nprt:nickname">Flyers</name>
+                            <name role="nrol:short">Philadelphia</name>
+                            <name role="nrol:alternate">Flyers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1165,8 +1165,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.2">
                             <name role="nrol:full">New York Islanders</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Islanders</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Islanders</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1201,8 +1201,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.3">
                             <name role="nrol:full">New York Rangers</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Rangers</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Rangers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1245,8 +1245,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.1">
                             <name role="nrol:full">New Jersey Devils</name>
-                            <name part="nprt:common">New Jersey</name>
-                            <name part="nprt:nickname">Devils</name>
+                            <name role="nrol:short">New Jersey</name>
+                            <name role="nrol:alternate">Devils</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1289,8 +1289,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.8">
                             <name role="nrol:full">Washington Capitals</name>
-                            <name part="nprt:common">Washington</name>
-                            <name part="nprt:nickname">Capitals</name>
+                            <name role="nrol:short">Washington</name>
+                            <name role="nrol:alternate">Capitals</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1341,8 +1341,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.7">
                             <name role="nrol:full">Tampa Bay Lightning</name>
-                            <name part="nprt:common">Tampa Bay</name>
-                            <name part="nprt:nickname">Lightning</name>
+                            <name role="nrol:short">Tampa Bay</name>
+                            <name role="nrol:alternate">Lightning</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1355,8 +1355,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.14">
                             <name role="nrol:full">Ottawa Senators</name>
-                            <name part="nprt:common">Ottawa</name>
-                            <name part="nprt:nickname">Senators</name>
+                            <name role="nrol:short">Ottawa</name>
+                            <name role="nrol:alternate">Senators</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1369,8 +1369,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.12">
                             <name role="nrol:full">Buffalo Sabres</name>
-                            <name part="nprt:common">Buffalo</name>
-                            <name part="nprt:nickname">Sabres</name>
+                            <name role="nrol:short">Buffalo</name>
+                            <name role="nrol:alternate">Sabres</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1383,8 +1383,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.11">
                             <name role="nrol:full">Boston Bruins</name>
-                            <name part="nprt:common">Boston</name>
-                            <name part="nprt:nickname">Bruins</name>
+                            <name role="nrol:short">Boston</name>
+                            <name role="nrol:alternate">Bruins</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1400,8 +1400,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.13">
                             <name role="nrol:full">Montreal Canadiens</name>
-                            <name part="nprt:common">Montreal</name>
-                            <name part="nprt:nickname">Canadiens</name>
+                            <name role="nrol:short">Montreal</name>
+                            <name role="nrol:alternate">Canadiens</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1417,8 +1417,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.10">
                             <name role="nrol:full">Florida Panthers</name>
-                            <name part="nprt:common">Florida</name>
-                            <name part="nprt:nickname">Panthers</name>
+                            <name role="nrol:short">Florida</name>
+                            <name role="nrol:alternate">Panthers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1431,8 +1431,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.15">
                             <name role="nrol:full">Toronto Maple Leafs</name>
-                            <name part="nprt:common">Toronto</name>
-                            <name part="nprt:nickname">Maple Leafs</name>
+                            <name role="nrol:short">Toronto</name>
+                            <name role="nrol:alternate">Maple Leafs</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1445,8 +1445,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.17">
                             <name role="nrol:full">Detroit Red Wings</name>
-                            <name part="nprt:common">Detroit</name>
-                            <name part="nprt:nickname">Red Wings</name>
+                            <name role="nrol:short">Detroit</name>
+                            <name role="nrol:alternate">Red Wings</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals competition="spct:league"
@@ -1471,8 +1471,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.7">
                             <name role="nrol:full">Tampa Bay Lightning</name>
-                            <name part="nprt:common">Tampa Bay</name>
-                            <name part="nprt:nickname">Lightning</name>
+                            <name role="nrol:short">Tampa Bay</name>
+                            <name role="nrol:alternate">Lightning</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1515,8 +1515,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.14">
                             <name role="nrol:full">Ottawa Senators</name>
-                            <name part="nprt:common">Ottawa</name>
-                            <name part="nprt:nickname">Senators</name>
+                            <name role="nrol:short">Ottawa</name>
+                            <name role="nrol:alternate">Senators</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1559,8 +1559,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.12">
                             <name role="nrol:full">Buffalo Sabres</name>
-                            <name part="nprt:common">Buffalo</name>
-                            <name part="nprt:nickname">Sabres</name>
+                            <name role="nrol:short">Buffalo</name>
+                            <name role="nrol:alternate">Sabres</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1599,8 +1599,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.11">
                             <name role="nrol:full">Boston Bruins</name>
-                            <name part="nprt:common">Boston</name>
-                            <name part="nprt:nickname">Bruins</name>
+                            <name role="nrol:short">Boston</name>
+                            <name role="nrol:alternate">Bruins</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1639,8 +1639,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.13">
                             <name role="nrol:full">Montreal Canadiens</name>
-                            <name part="nprt:common">Montreal</name>
-                            <name part="nprt:nickname">Canadiens</name>
+                            <name role="nrol:short">Montreal</name>
+                            <name role="nrol:alternate">Canadiens</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1679,8 +1679,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.10">
                             <name role="nrol:full">Florida Panthers</name>
-                            <name part="nprt:common">Florida</name>
-                            <name part="nprt:nickname">Panthers</name>
+                            <name role="nrol:short">Florida</name>
+                            <name role="nrol:alternate">Panthers</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1715,8 +1715,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.15">
                             <name role="nrol:full">Toronto Maple Leafs</name>
-                            <name part="nprt:common">Toronto</name>
-                            <name part="nprt:nickname">Maple Leafs</name>
+                            <name role="nrol:short">Toronto</name>
+                            <name role="nrol:alternate">Maple Leafs</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"
@@ -1780,8 +1780,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.17">
                             <name role="nrol:full">Detroit Red Wings</name>
-                            <name part="nprt:common">Detroit</name>
-                            <name part="nprt:nickname">Red Wings</name>
+                            <name role="nrol:short">Detroit</name>
+                            <name role="nrol:alternate">Red Wings</name>
                         </team-metadata>
                         <team-stats>
                             <outcome-totals unit-type="spct:division"

--- a/3.0/examples/ice-hockey-standings-g2-specific.xml
+++ b/3.0/examples/ice-hockey-standings-g2-specific.xml
@@ -63,8 +63,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.24">
                             <name role="nrol:full">San Jose Sharks</name>
-                            <name part="nprt:common">San Jose</name>
-                            <name part="nprt:nickname">Sharks</name>
+                            <name role="nrol:short">San Jose</name>
+                            <name role="nrol:alternate">Sharks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -77,8 +77,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.28">
                             <name role="nrol:full">Calgary Flames</name>
-                            <name part="nprt:common">Calgary</name>
-                            <name part="nprt:nickname">Flames</name>
+                            <name role="nrol:short">Calgary</name>
+                            <name role="nrol:alternate">Flames</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -91,8 +91,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.25">
                             <name role="nrol:full">Arizona Coyotes</name>
-                            <name part="nprt:common">Arizona</name>
-                            <name part="nprt:nickname">Coyotes</name>
+                            <name role="nrol:short">Arizona</name>
+                            <name role="nrol:alternate">Coyotes</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -105,8 +105,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.22">
                             <name role="nrol:full">Anaheim Ducks</name>
-                            <name part="nprt:common">Anaheim</name>
-                            <name part="nprt:nickname">Ducks</name>
+                            <name role="nrol:short">Anaheim</name>
+                            <name role="nrol:alternate">Ducks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -119,8 +119,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.23">
                             <name role="nrol:full">Los Angeles Kings</name>
-                            <name part="nprt:common">Los Angeles</name>
-                            <name part="nprt:nickname">Kings</name>
+                            <name role="nrol:short">Los Angeles</name>
+                            <name role="nrol:alternate">Kings</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -133,8 +133,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.29">
                             <name role="nrol:full">Edmonton Oilers</name>
-                            <name part="nprt:common">Edmonton</name>
-                            <name part="nprt:nickname">Oilers</name>
+                            <name role="nrol:short">Edmonton</name>
+                            <name role="nrol:alternate">Oilers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -147,8 +147,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.26">
                             <name role="nrol:full">Vancouver Canucks</name>
-                            <name part="nprt:common">Vancouver</name>
-                            <name part="nprt:nickname">Canucks</name>
+                            <name role="nrol:short">Vancouver</name>
+                            <name role="nrol:alternate">Canucks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -173,8 +173,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.24">
                             <name role="nrol:full">San Jose Sharks</name>
-                            <name part="nprt:common">San Jose</name>
-                            <name part="nprt:nickname">Sharks</name>
+                            <name role="nrol:short">San Jose</name>
+                            <name role="nrol:alternate">Sharks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -217,8 +217,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.28">
                             <name role="nrol:full">Calgary Flames</name>
-                            <name part="nprt:common">Calgary</name>
-                            <name part="nprt:nickname">Flames</name>
+                            <name role="nrol:short">Calgary</name>
+                            <name role="nrol:alternate">Flames</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -261,8 +261,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.25">
                             <name role="nrol:full">Arizona Coyotes</name>
-                            <name part="nprt:common">Arizona</name>
-                            <name part="nprt:nickname">Coyotes</name>
+                            <name role="nrol:short">Arizona</name>
+                            <name role="nrol:alternate">Coyotes</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -305,8 +305,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.22">
                             <name role="nrol:full">Anaheim Ducks</name>
-                            <name part="nprt:common">Anaheim</name>
-                            <name part="nprt:nickname">Ducks</name>
+                            <name role="nrol:short">Anaheim</name>
+                            <name role="nrol:alternate">Ducks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -344,8 +344,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.23">
                             <name role="nrol:full">Los Angeles Kings</name>
-                            <name part="nprt:common">Los Angeles</name>
-                            <name part="nprt:nickname">Kings</name>
+                            <name role="nrol:short">Los Angeles</name>
+                            <name role="nrol:alternate">Kings</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -384,8 +384,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.29">
                             <name role="nrol:full">Edmonton Oilers</name>
-                            <name part="nprt:common">Edmonton</name>
-                            <name part="nprt:nickname">Oilers</name>
+                            <name role="nrol:short">Edmonton</name>
+                            <name role="nrol:alternate">Oilers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -420,8 +420,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.26">
                             <name role="nrol:full">Vancouver Canucks</name>
-                            <name part="nprt:common">Vancouver</name>
-                            <name part="nprt:nickname">Canucks</name>
+                            <name role="nrol:short">Vancouver</name>
+                            <name role="nrol:alternate">Canucks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -476,8 +476,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.18">
                             <name role="nrol:full">St. Louis Blues</name>
-                            <name part="nprt:common">St. Louis</name>
-                            <name part="nprt:nickname">Blues</name>
+                            <name role="nrol:short">St. Louis</name>
+                            <name role="nrol:alternate">Blues</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -490,8 +490,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.21">
                             <name role="nrol:full">Dallas Stars</name>
-                            <name part="nprt:common">Dallas</name>
-                            <name part="nprt:nickname">Stars</name>
+                            <name role="nrol:short">Dallas</name>
+                            <name role="nrol:alternate">Stars</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -504,8 +504,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.27">
                             <name role="nrol:full">Colorado Avalanche</name>
-                            <name part="nprt:common">Colorado</name>
-                            <name part="nprt:nickname">Avalanche</name>
+                            <name role="nrol:short">Colorado</name>
+                            <name role="nrol:alternate">Avalanche</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -521,8 +521,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.16">
                             <name role="nrol:full">Chicago Blackhawks</name>
-                            <name part="nprt:common">Chicago</name>
-                            <name part="nprt:nickname">Blackhawks</name>
+                            <name role="nrol:short">Chicago</name>
+                            <name role="nrol:alternate">Blackhawks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -535,8 +535,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.19">
                             <name role="nrol:full">Nashville Predators</name>
-                            <name part="nprt:common">Nashville</name>
-                            <name part="nprt:nickname">Predators</name>
+                            <name role="nrol:short">Nashville</name>
+                            <name role="nrol:alternate">Predators</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -549,8 +549,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.30">
                             <name role="nrol:full">Minnesota Wild</name>
-                            <name part="nprt:common">Minnesota</name>
-                            <name part="nprt:nickname">Wild</name>
+                            <name role="nrol:short">Minnesota</name>
+                            <name role="nrol:alternate">Wild</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -563,8 +563,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.9">
                             <name role="nrol:full">Winnipeg Jets</name>
-                            <name part="nprt:common">Winnipeg</name>
-                            <name part="nprt:nickname">Jets</name>
+                            <name role="nrol:short">Winnipeg</name>
+                            <name role="nrol:alternate">Jets</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -589,8 +589,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.18">
                             <name role="nrol:full">St. Louis Blues</name>
-                            <name part="nprt:common">St. Louis</name>
-                            <name part="nprt:nickname">Blues</name>
+                            <name role="nrol:short">St. Louis</name>
+                            <name role="nrol:alternate">Blues</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -633,8 +633,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.21">
                             <name role="nrol:full">Dallas Stars</name>
-                            <name part="nprt:common">Dallas</name>
-                            <name part="nprt:nickname">Stars</name>
+                            <name role="nrol:short">Dallas</name>
+                            <name role="nrol:alternate">Stars</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -677,8 +677,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.27">
                             <name role="nrol:full">Colorado Avalanche</name>
-                            <name part="nprt:common">Colorado</name>
-                            <name part="nprt:nickname">Avalanche</name>
+                            <name role="nrol:short">Colorado</name>
+                            <name role="nrol:alternate">Avalanche</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -717,8 +717,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.16">
                             <name role="nrol:full">Chicago Blackhawks</name>
-                            <name part="nprt:common">Chicago</name>
-                            <name part="nprt:nickname">Blackhawks</name>
+                            <name role="nrol:short">Chicago</name>
+                            <name role="nrol:alternate">Blackhawks</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -753,8 +753,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.19">
                             <name role="nrol:full">Nashville Predators</name>
-                            <name part="nprt:common">Nashville</name>
-                            <name part="nprt:nickname">Predators</name>
+                            <name role="nrol:short">Nashville</name>
+                            <name role="nrol:alternate">Predators</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -789,8 +789,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.30">
                             <name role="nrol:full">Minnesota Wild</name>
-                            <name part="nprt:common">Minnesota</name>
-                            <name part="nprt:nickname">Wild</name>
+                            <name role="nrol:short">Minnesota</name>
+                            <name role="nrol:alternate">Wild</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -833,8 +833,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.9">
                             <name role="nrol:full">Winnipeg Jets</name>
-                            <name part="nprt:common">Winnipeg</name>
-                            <name part="nprt:nickname">Jets</name>
+                            <name role="nrol:short">Winnipeg</name>
+                            <name role="nrol:alternate">Jets</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -877,8 +877,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.20">
                             <name role="nrol:full">Columbus Blue Jackets</name>
-                            <name part="nprt:common">Columbus</name>
-                            <name part="nprt:nickname">Blue Jackets</name>
+                            <name role="nrol:short">Columbus</name>
+                            <name role="nrol:alternate">Blue Jackets</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -894,8 +894,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.5">
                             <name role="nrol:full">Pittsburgh Penguins</name>
-                            <name part="nprt:common">Pittsburgh</name>
-                            <name part="nprt:nickname">Penguins</name>
+                            <name role="nrol:short">Pittsburgh</name>
+                            <name role="nrol:alternate">Penguins</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -908,8 +908,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.6">
                             <name role="nrol:full">Carolina Hurricanes</name>
-                            <name part="nprt:common">Carolina</name>
-                            <name part="nprt:nickname">Hurricanes</name>
+                            <name role="nrol:short">Carolina</name>
+                            <name role="nrol:alternate">Hurricanes</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -922,8 +922,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.4">
                             <name role="nrol:full">Philadelphia Flyers</name>
-                            <name part="nprt:common">Philadelphia</name>
-                            <name part="nprt:nickname">Flyers</name>
+                            <name role="nrol:short">Philadelphia</name>
+                            <name role="nrol:alternate">Flyers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -939,8 +939,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.2">
                             <name role="nrol:full">New York Islanders</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Islanders</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Islanders</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -953,8 +953,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.3">
                             <name role="nrol:full">New York Rangers</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Rangers</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Rangers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -970,8 +970,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.1">
                             <name role="nrol:full">New Jersey Devils</name>
-                            <name part="nprt:common">New Jersey</name>
-                            <name part="nprt:nickname">Devils</name>
+                            <name role="nrol:short">New Jersey</name>
+                            <name role="nrol:alternate">Devils</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -984,8 +984,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.8">
                             <name role="nrol:full">Washington Capitals</name>
-                            <name part="nprt:common">Washington</name>
-                            <name part="nprt:nickname">Capitals</name>
+                            <name role="nrol:short">Washington</name>
+                            <name role="nrol:alternate">Capitals</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1013,8 +1013,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.20">
                             <name role="nrol:full">Columbus Blue Jackets</name>
-                            <name part="nprt:common">Columbus</name>
-                            <name part="nprt:nickname">Blue Jackets</name>
+                            <name role="nrol:short">Columbus</name>
+                            <name role="nrol:alternate">Blue Jackets</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1057,8 +1057,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.5">
                             <name role="nrol:full">Pittsburgh Penguins</name>
-                            <name part="nprt:common">Pittsburgh</name>
-                            <name part="nprt:nickname">Penguins</name>
+                            <name role="nrol:short">Pittsburgh</name>
+                            <name role="nrol:alternate">Penguins</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1089,8 +1089,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.6">
                             <name role="nrol:full">Carolina Hurricanes</name>
-                            <name part="nprt:common">Carolina</name>
-                            <name part="nprt:nickname">Hurricanes</name>
+                            <name role="nrol:short">Carolina</name>
+                            <name role="nrol:alternate">Hurricanes</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1129,8 +1129,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.4">
                             <name role="nrol:full">Philadelphia Flyers</name>
-                            <name part="nprt:common">Philadelphia</name>
-                            <name part="nprt:nickname">Flyers</name>
+                            <name role="nrol:short">Philadelphia</name>
+                            <name role="nrol:alternate">Flyers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1165,8 +1165,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.2">
                             <name role="nrol:full">New York Islanders</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Islanders</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Islanders</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1201,8 +1201,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.3">
                             <name role="nrol:full">New York Rangers</name>
-                            <name part="nprt:common">New York</name>
-                            <name part="nprt:nickname">Rangers</name>
+                            <name role="nrol:short">New York</name>
+                            <name role="nrol:alternate">Rangers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1245,8 +1245,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.1">
                             <name role="nrol:full">New Jersey Devils</name>
-                            <name part="nprt:common">New Jersey</name>
-                            <name part="nprt:nickname">Devils</name>
+                            <name role="nrol:short">New Jersey</name>
+                            <name role="nrol:alternate">Devils</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1289,8 +1289,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.8">
                             <name role="nrol:full">Washington Capitals</name>
-                            <name part="nprt:common">Washington</name>
-                            <name part="nprt:nickname">Capitals</name>
+                            <name role="nrol:short">Washington</name>
+                            <name role="nrol:alternate">Capitals</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1341,8 +1341,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.7">
                             <name role="nrol:full">Tampa Bay Lightning</name>
-                            <name part="nprt:common">Tampa Bay</name>
-                            <name part="nprt:nickname">Lightning</name>
+                            <name role="nrol:short">Tampa Bay</name>
+                            <name role="nrol:alternate">Lightning</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1355,8 +1355,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.14">
                             <name role="nrol:full">Ottawa Senators</name>
-                            <name part="nprt:common">Ottawa</name>
-                            <name part="nprt:nickname">Senators</name>
+                            <name role="nrol:short">Ottawa</name>
+                            <name role="nrol:alternate">Senators</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1369,8 +1369,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.12">
                             <name role="nrol:full">Buffalo Sabres</name>
-                            <name part="nprt:common">Buffalo</name>
-                            <name part="nprt:nickname">Sabres</name>
+                            <name role="nrol:short">Buffalo</name>
+                            <name role="nrol:alternate">Sabres</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1383,8 +1383,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.11">
                             <name role="nrol:full">Boston Bruins</name>
-                            <name part="nprt:common">Boston</name>
-                            <name part="nprt:nickname">Bruins</name>
+                            <name role="nrol:short">Boston</name>
+                            <name role="nrol:alternate">Bruins</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1400,8 +1400,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.13">
                             <name role="nrol:full">Montreal Canadiens</name>
-                            <name part="nprt:common">Montreal</name>
-                            <name part="nprt:nickname">Canadiens</name>
+                            <name role="nrol:short">Montreal</name>
+                            <name role="nrol:alternate">Canadiens</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1417,8 +1417,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.10">
                             <name role="nrol:full">Florida Panthers</name>
-                            <name part="nprt:common">Florida</name>
-                            <name part="nprt:nickname">Panthers</name>
+                            <name role="nrol:short">Florida</name>
+                            <name role="nrol:alternate">Panthers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1431,8 +1431,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.15">
                             <name role="nrol:full">Toronto Maple Leafs</name>
-                            <name part="nprt:common">Toronto</name>
-                            <name part="nprt:nickname">Maple Leafs</name>
+                            <name role="nrol:short">Toronto</name>
+                            <name role="nrol:alternate">Maple Leafs</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1445,8 +1445,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.17">
                             <name role="nrol:full">Detroit Red Wings</name>
-                            <name part="nprt:common">Detroit</name>
-                            <name part="nprt:nickname">Red Wings</name>
+                            <name role="nrol:short">Detroit</name>
+                            <name role="nrol:alternate">Red Wings</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-exhibition">
                             <outcome-totals competition="spct:league"
@@ -1471,8 +1471,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.7">
                             <name role="nrol:full">Tampa Bay Lightning</name>
-                            <name part="nprt:common">Tampa Bay</name>
-                            <name part="nprt:nickname">Lightning</name>
+                            <name role="nrol:short">Tampa Bay</name>
+                            <name role="nrol:alternate">Lightning</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1515,8 +1515,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.14">
                             <name role="nrol:full">Ottawa Senators</name>
-                            <name part="nprt:common">Ottawa</name>
-                            <name part="nprt:nickname">Senators</name>
+                            <name role="nrol:short">Ottawa</name>
+                            <name role="nrol:alternate">Senators</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1559,8 +1559,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.12">
                             <name role="nrol:full">Buffalo Sabres</name>
-                            <name part="nprt:common">Buffalo</name>
-                            <name part="nprt:nickname">Sabres</name>
+                            <name role="nrol:short">Buffalo</name>
+                            <name role="nrol:alternate">Sabres</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1599,8 +1599,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.11">
                             <name role="nrol:full">Boston Bruins</name>
-                            <name part="nprt:common">Boston</name>
-                            <name part="nprt:nickname">Bruins</name>
+                            <name role="nrol:short">Boston</name>
+                            <name role="nrol:alternate">Bruins</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1639,8 +1639,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.13">
                             <name role="nrol:full">Montreal Canadiens</name>
-                            <name part="nprt:common">Montreal</name>
-                            <name part="nprt:nickname">Canadiens</name>
+                            <name role="nrol:short">Montreal</name>
+                            <name role="nrol:alternate">Canadiens</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1679,8 +1679,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.10">
                             <name role="nrol:full">Florida Panthers</name>
-                            <name part="nprt:common">Florida</name>
-                            <name part="nprt:nickname">Panthers</name>
+                            <name role="nrol:short">Florida</name>
+                            <name role="nrol:alternate">Panthers</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1715,8 +1715,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.15">
                             <name role="nrol:full">Toronto Maple Leafs</name>
-                            <name part="nprt:common">Toronto</name>
-                            <name part="nprt:nickname">Maple Leafs</name>
+                            <name role="nrol:short">Toronto</name>
+                            <name role="nrol:alternate">Maple Leafs</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"
@@ -1780,8 +1780,8 @@
                     <team>
                         <team-metadata key="vendteam:l.nhl.com-t.17">
                             <name role="nrol:full">Detroit Red Wings</name>
-                            <name part="nprt:common">Detroit</name>
-                            <name part="nprt:nickname">Red Wings</name>
+                            <name role="nrol:short">Detroit</name>
+                            <name role="nrol:alternate">Red Wings</name>
                         </team-metadata>
                         <team-stats temporal-unit-type="spct:season-regular">
                             <outcome-totals unit-type="spct:division"

--- a/3.0/examples/rugby-match-classic-generic-3.0.xml
+++ b/3.0/examples/rugby-match-classic-generic-3.0.xml
@@ -29,7 +29,7 @@
             <site>
                 <site-metadata>
                     <name role="nrol:full">The Recreation Ground</name>
-                    <name part="nprt:common">The Recreation Ground</name>
+                    <name role="nrol:short">The Recreation Ground</name>
                 </site-metadata>
                 <site-stats attendance="13,300"/>
             </site>
@@ -37,7 +37,7 @@
         <team id="t.33094">
             <team-metadata key="vendteam:t.33094" alignment="home">
                 <name role="nrol:full">Bath</name>
-                <name part="nprt:common">Bath</name>
+                <name role="nrol:short">Bath</name>
             </team-metadata>
             <team-stats>
                 <stats>
@@ -428,7 +428,7 @@
         <team id="t.33286">
             <team-metadata key="vendteam:t.33286" alignment="away">
                 <name role="nrol:full">Northampton</name>
-                <name part="nprt:common">Northampton</name>
+                <name role="nrol:short">Northampton</name>
             </team-metadata>
             <team-stats>
                 <stats>

--- a/3.0/examples/rugby-match-g2-generic-3.0.xml
+++ b/3.0/examples/rugby-match-g2-generic-3.0.xml
@@ -64,7 +64,7 @@
                         <site>
                             <site-metadata>
                                 <name role="nrol:full">The Recreation Ground</name>
-                                <name part="nprt:common">The Recreation Ground</name>
+                                <name role="nrol:short">The Recreation Ground</name>
                             </site-metadata>
                             <site-stats attendance="13,300"/>
                         </site>
@@ -72,7 +72,7 @@
                     <team id="t.33094">
                         <team-metadata key="vendteam:t.33094" alignment="home">
                             <name role="nrol:full">Bath</name>
-                            <name part="nprt:common">Bath</name>
+                            <name role="nrol:short">Bath</name>
                         </team-metadata>
                         <team-stats>
                             <stats>
@@ -475,7 +475,7 @@
                     <team id="t.33286">
                         <team-metadata key="vendteam:t.33286" alignment="away">
                             <name role="nrol:full">Northampton</name>
-                            <name part="nprt:common">Northampton</name>
+                            <name role="nrol:short">Northampton</name>
                         </team-metadata>
                         <team-stats>
                             <stats>

--- a/3.0/examples/skiing_vasaloppet_2015_g2.xml
+++ b/3.0/examples/skiing_vasaloppet_2015_g2.xml
@@ -59,8 +59,8 @@
                             <player>
                                 <player-metadata date-of-birth="1985" gender="male"
                                     nationality="Norge" uniform-number="131">
-                                    <name part="nprt:first">Petter</name>
-                                    <name part="nprt:last">Eliassen</name>
+                                    <name part="nprt:given">Petter</name>
+                                    <name part="nprt:family">Eliassen</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Nannestad</name></locality><area><name/></area><country><name>Norge</name></country><postalCode>2030</postalCode></address>
@@ -74,8 +74,8 @@
                             <player>
                                 <player-metadata date-of-birth="1972" gender="male"
                                     nationality="Norge" uniform-number="123">
-                                    <name part="nprt:first">Anders</name>
-                                    <name part="nprt:last">Aukland</name>
+                                    <name part="nprt:given">Anders</name>
+                                    <name part="nprt:family">Aukland</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Oslo</name></locality><area><name/></area><country><name>Norge</name></country><postalCode>0102</postalCode></address>
@@ -89,8 +89,8 @@
                             <player>
                                 <player-metadata date-of-birth="1973" gender="male"
                                     nationality="Tjeckien" uniform-number="5">
-                                    <name part="nprt:first">Stanislav</name>
-                                    <name part="nprt:last">Rezac</name>
+                                    <name part="nprt:given">Stanislav</name>
+                                    <name part="nprt:family">Rezac</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Jablonec nad Nisous</name></locality><area><name/></area><country><name>Tjeckien</name></country><postalCode/></address>
@@ -104,8 +104,8 @@
                             <player>
                                 <player-metadata date-of-birth="1983" gender="male"
                                     nationality="Norge" uniform-number="28">
-                                    <name part="nprt:first">Öystein</name>
-                                    <name part="nprt:last">Pettersen</name>
+                                    <name part="nprt:given">Öystein</name>
+                                    <name part="nprt:family">Pettersen</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Oslo</name></locality><area><name/></area><country><name>Norge</name></country><postalCode>0851</postalCode></address>
@@ -119,8 +119,8 @@
                             <player>
                                 <player-metadata date-of-birth="1981" gender="male"
                                     nationality="Norge" uniform-number="1">
-                                    <name part="nprt:first">Kristian</name>
-                                    <name part="nprt:last">Dahl</name>
+                                    <name part="nprt:given">Kristian</name>
+                                    <name part="nprt:family">Dahl</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Trondheim</name></locality><area><name/></area><country><name>Norge</name></country><postalCode>7022</postalCode></address>
@@ -134,8 +134,8 @@
                             <player>
                                 <player-metadata date-of-birth="1983" gender="male"
                                     nationality="Norge" uniform-number="124">
-                                    <name part="nprt:first">Tord Asle</name>
-                                    <name part="nprt:last">Gjerdalen</name>
+                                    <name part="nprt:given">Tord Asle</name>
+                                    <name part="nprt:family">Gjerdalen</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Oslo</name></locality><area><name/></area><country><name>Norge</name></country><postalCode>12345</postalCode></address>
@@ -149,8 +149,8 @@
                             <player>
                                 <player-metadata date-of-birth="1984" gender="male"
                                     nationality="Norge" uniform-number="35">
-                                    <name part="nprt:first"/>
-                                    <name part="nprt:last"/>
+                                    <name part="nprt:given"/>
+                                    <name part="nprt:family"/>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Hosle</name></locality><area><name/></area><country><name>Norge</name></country><postalCode>1362</postalCode></address>
@@ -164,8 +164,8 @@
                             <player>
                                 <player-metadata date-of-birth="1978" gender="male"
                                     nationality="Sverige" uniform-number="23">
-                                    <name part="nprt:first">Jerry</name>
-                                    <name part="nprt:last">Ahrlin</name>
+                                    <name part="nprt:given">Jerry</name>
+                                    <name part="nprt:family">Ahrlin</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Östersund</name></locality><area><name>Jämtland</name></area><country><name>Sverige</name></country><postalCode>831 32</postalCode></address>
@@ -193,8 +193,8 @@
                             <player>
                                 <player-metadata date-of-birth="1983" gender="female"
                                     nationality="Polen" uniform-number="513">
-                                    <name part="nprt:first">Justyna</name>
-                                    <name part="nprt:last">Kowalczyk</name>
+                                    <name part="nprt:given">Justyna</name>
+                                    <name part="nprt:family">Kowalczyk</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name/></locality><area><name/></area><country><name>Polen</name></country><postalCode/></address>
@@ -208,8 +208,8 @@
                             <player>
                                 <player-metadata date-of-birth="1983" gender="female"
                                     nationality="Sverige" uniform-number="502">
-                                    <name part="nprt:first">Britta</name>
-                                    <name part="nprt:last">Johansson Norgren</name>
+                                    <name part="nprt:given">Britta</name>
+                                    <name part="nprt:family">Johansson Norgren</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Östersund</name></locality><area><name>Jämtland</name></area><country><name>Sverige</name></country><postalCode>831 62</postalCode></address>
@@ -223,8 +223,8 @@
                             <player>
                                 <player-metadata date-of-birth="1982" gender="female"
                                     nationality="Schweiz" uniform-number="505">
-                                    <name part="nprt:first">Seraina</name>
-                                    <name part="nprt:last">Boner</name>
+                                    <name part="nprt:given">Seraina</name>
+                                    <name part="nprt:family">Boner</name>
                                     <home-location>
                                         <POIDetails>
                                             <address><locality><name>Davos-Platz</name></locality><area><name>Graubünden</name></area><country><name>Schweiz</name></country><postalCode>7270</postalCode></address>

--- a/3.0/examples/soccer-match-classic-generic.xml
+++ b/3.0/examples/soccer-match-classic-generic.xml
@@ -31,7 +31,7 @@
             <site>
                 <site-metadata key="vendsite:s.34">
                     <name role="nrol:full">Villa Park</name>
-                    <name part="nprt:common">Villa Park</name>
+                    <name role="nrol:short">Villa Park</name>
                     <home-location>
                         <POIDetails>
                             <address><country><name>England</name></country></address>
@@ -47,7 +47,7 @@
         <team id="e.755363-t.7">
             <team-metadata key="vendteam:o.thefa.com-t.2" alignment="home">
                 <name role="nrol:full">Aston Villa</name>
-                <name part="nprt:common">Aston Villa</name>
+                <name role="nrol:short">Aston Villa</name>
             </team-metadata>
             <team-stats>
                 <stats>
@@ -608,7 +608,7 @@
         <team id="e.755363-t.43">
             <team-metadata key="vendteam:o.thefa.com-t.12" alignment="away">
                 <name role="nrol:full">Manchester City</name>
-                <name part="nprt:common">Manchester City</name>
+                <name role="nrol:short">Manchester City</name>
             </team-metadata>
             <team-stats>
                 <stats>

--- a/3.0/examples/soccer-match-classic-specific.xml
+++ b/3.0/examples/soccer-match-classic-specific.xml
@@ -31,7 +31,7 @@
             <site>
                 <site-metadata key="vendsite:s.34">
                     <name role="nrol:full">Villa Park</name>
-                    <name part="nprt:common">Villa Park</name>
+                    <name role="nrol:short">Villa Park</name>
                     <home-location>
                         <POIDetails>
                             <address><country><name>England</name></country></address>
@@ -47,7 +47,7 @@
         <team id="e.755363-t.7">
             <team-metadata key="vendteam:o.thefa.com-t.2" alignment="home">
                 <name role="nrol:full">Aston Villa</name>
-                <name part="nprt:common">Aston Villa</name>
+                <name role="nrol:short">Aston Villa</name>
             </team-metadata>
             <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss"
                 time-of-possession-percentage="31.6">
@@ -306,7 +306,7 @@
         <team id="e.755363-t.43">
             <team-metadata key="vendteam:o.thefa.com-t.12" alignment="away">
                 <name role="nrol:full">Manchester City</name>
-                <name part="nprt:common">Manchester City</name>
+                <name role="nrol:short">Manchester City</name>
             </team-metadata>
             <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win"
                 time-of-possession-percentage="68.4">

--- a/3.0/examples/soccer-match-g2-generic.xml
+++ b/3.0/examples/soccer-match-g2-generic.xml
@@ -64,7 +64,7 @@
                         <site>
                             <site-metadata key="vendsite:s.34">
                                 <name role="nrol:full">Villa Park</name>
-                                <name part="nprt:common">Villa Park</name>
+                                <name role="nrol:short">Villa Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address><country><name>England</name></country></address>
@@ -80,7 +80,7 @@
                     <team id="e.755363-t.7">
                         <team-metadata key="vendteam:o.thefa.com-t.2" alignment="home">
                             <name role="nrol:full">Aston Villa</name>
-                            <name part="nprt:common">Aston Villa</name>
+                            <name role="nrol:short">Aston Villa</name>
                         </team-metadata>
                         <team-stats>
                             <stats>
@@ -679,7 +679,7 @@
                     <team id="e.755363-t.43">
                         <team-metadata key="vendteam:o.thefa.com-t.12" alignment="away">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats>
                             <stats>

--- a/3.0/examples/soccer-match-g2-specific.xml
+++ b/3.0/examples/soccer-match-g2-specific.xml
@@ -64,7 +64,7 @@
                         <site>
                             <site-metadata key="vendsite:s.34">
                                 <name role="nrol:full">Villa Park</name>
-                                <name part="nprt:common">Villa Park</name>
+                                <name role="nrol:short">Villa Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address><country><name>England</name></country></address>
@@ -80,7 +80,7 @@
                     <team id="e.755363-t.7">
                         <team-metadata key="vendteam:o.thefa.com-t.2" alignment="home">
                             <name role="nrol:full">Aston Villa</name>
-                            <name part="nprt:common">Aston Villa</name>
+                            <name role="nrol:short">Aston Villa</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss"
                             time-of-possession-percentage="31.6">
@@ -370,7 +370,7 @@
                     <team id="e.755363-t.43">
                         <team-metadata key="vendteam:o.thefa.com-t.12" alignment="away">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win"
                             time-of-possession-percentage="68.4">

--- a/3.0/examples/soccer-season-stats-classic-generic.xml
+++ b/3.0/examples/soccer-season-stats-classic-generic.xml
@@ -26,7 +26,7 @@
         <team>
             <team-metadata key="vendteam:o.thefa.com-t.5">
                 <name role="nrol:full">Chelsea</name>
-                <name part="nprt:common">Chelsea</name>
+                <name role="nrol:short">Chelsea</name>
             </team-metadata>
             <team-stats>
                 <stats>

--- a/3.0/examples/soccer-season-stats-classic-specific.xml
+++ b/3.0/examples/soccer-season-stats-classic-specific.xml
@@ -26,7 +26,7 @@
         <team>
             <team-metadata key="vendteam:o.thefa.com-t.5">
                 <name role="nrol:full">Chelsea</name>
-                <name part="nprt:common">Chelsea</name>
+                <name role="nrol:short">Chelsea</name>
             </team-metadata>
             <team-stats time-of-possession-percentage="58" events-played="9">
                 <team-stats-soccer>

--- a/3.0/examples/soccer-season-stats-g2-generic.xml
+++ b/3.0/examples/soccer-season-stats-g2-generic.xml
@@ -54,7 +54,7 @@
                     <team>
                         <team-metadata key="vendteam:o.thefa.com-t.5">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats>
                             <stats>

--- a/3.0/examples/soccer-season-stats-g2-specific.xml
+++ b/3.0/examples/soccer-season-stats-g2-specific.xml
@@ -54,7 +54,7 @@
                     <team>
                         <team-metadata key="vendteam:o.thefa.com-t.5">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats time-of-possession-percentage="58" events-played="9">
                             <team-stats-soccer>

--- a/3.0/examples/soccer-standings-classic-specific.xml
+++ b/3.0/examples/soccer-standings-classic-specific.xml
@@ -28,7 +28,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.198">
                 <name role="nrol:full">FC Bayern München</name>
-                <name part="nprt:common">FC Bayern München</name>
+                <name role="nrol:short">FC Bayern München</name>
             </team-metadata>
             <team-stats events-played="7">
                 <outcome-totals alignment-scope="events-all" events-played="7" standing-points="21"
@@ -49,7 +49,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.286">
                 <name role="nrol:full">Borussia Dortmund</name>
-                <name part="nprt:common">Borussia Dortmund</name>
+                <name role="nrol:short">Borussia Dortmund</name>
             </team-metadata>
             <team-stats events-played="7">
                 <outcome-totals alignment-scope="events-all" events-played="7" standing-points="17"
@@ -70,7 +70,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.358">
                 <name role="nrol:full">FC Schalke 04</name>
-                <name part="nprt:common">FC Schalke 04</name>
+                <name role="nrol:short">FC Schalke 04</name>
             </team-metadata>
             <team-stats events-played="7">
                 <outcome-totals alignment-scope="events-all" events-played="7" standing-points="16"
@@ -91,7 +91,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.701">
                 <name role="nrol:full">Hertha BSC</name>
-                <name part="nprt:common">Hertha BSC</name>
+                <name role="nrol:short">Hertha BSC</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="14"
@@ -112,7 +112,7 @@
         <team>
             <team-metadata key="vendteam:t.2743">
                 <name role="nrol:full">FC Ingolstadt 04</name>
-                <name part="nprt:common">FC Ingolstadt 04</name>
+                <name role="nrol:short">FC Ingolstadt 04</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="14"
@@ -133,7 +133,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.1445">
                 <name role="nrol:full">1. FSV Mainz 05</name>
-                <name part="nprt:common">1. FSV Mainz 05</name>
+                <name role="nrol:short">1. FSV Mainz 05</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="12"
@@ -154,7 +154,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.700">
                 <name role="nrol:full">VfL Wolfsburg</name>
-                <name part="nprt:common">VfL Wolfsburg</name>
+                <name role="nrol:short">VfL Wolfsburg</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="12"
@@ -173,7 +173,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.353">
                 <name role="nrol:full">Bayer 04 Leverkusen</name>
-                <name part="nprt:common">Bayer 04 Leverkusen</name>
+                <name role="nrol:short">Bayer 04 Leverkusen</name>
             </team-metadata>
             <team-stats events-played="7">
                 <outcome-totals alignment-scope="events-all" events-played="7" standing-points="12"
@@ -192,7 +192,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.1457">
                 <name role="nrol:full">1. FC Köln</name>
-                <name part="nprt:common">1. FC Köln</name>
+                <name role="nrol:short">1. FC Köln</name>
             </team-metadata>
             <team-stats events-played="7">
                 <outcome-totals alignment-scope="events-all" events-played="7" standing-points="11"
@@ -211,7 +211,7 @@
         <team>
             <team-metadata key="vendteam:t.1756">
                 <name role="nrol:full">SV Darmstadt 98</name>
-                <name part="nprt:common">SV Darmstadt 98</name>
+                <name role="nrol:short">SV Darmstadt 98</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="10"
@@ -230,7 +230,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.326">
                 <name role="nrol:full">Hamburger SV</name>
-                <name part="nprt:common">Hamburger SV</name>
+                <name role="nrol:short">Hamburger SV</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="10"
@@ -249,7 +249,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.926">
                 <name role="nrol:full">Eintracht Frankfurt</name>
-                <name part="nprt:common">Eintracht Frankfurt</name>
+                <name role="nrol:short">Eintracht Frankfurt</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="9"
@@ -268,7 +268,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.310">
                 <name role="nrol:full">Borussia Mönchengladbach</name>
-                <name part="nprt:common">Borussia Mönchengladbach</name>
+                <name role="nrol:short">Borussia Mönchengladbach</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="9"
@@ -287,7 +287,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.293">
                 <name role="nrol:full">SV Werder Bremen</name>
-                <name part="nprt:common">SV Werder Bremen</name>
+                <name role="nrol:short">SV Werder Bremen</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="7"
@@ -306,7 +306,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.2074">
                 <name role="nrol:full">TSG 1899 Hoffenheim</name>
-                <name part="nprt:common">TSG 1899 Hoffenheim</name>
+                <name role="nrol:short">TSG 1899 Hoffenheim</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="6"
@@ -325,7 +325,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.1452">
                 <name role="nrol:full">Hannover 96</name>
-                <name part="nprt:common">Hannover 96</name>
+                <name role="nrol:short">Hannover 96</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="5"
@@ -346,7 +346,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.1000">
                 <name role="nrol:full">FC Augsburg</name>
-                <name part="nprt:common">FC Augsburg</name>
+                <name role="nrol:short">FC Augsburg</name>
             </team-metadata>
             <team-stats events-played="7">
                 <outcome-totals alignment-scope="events-all" events-played="7" standing-points="4"
@@ -367,7 +367,7 @@
         <team>
             <team-metadata key="vendteam:o.dfb.de-t.352">
                 <name role="nrol:full">VfB Stuttgart</name>
-                <name part="nprt:common">VfB Stuttgart</name>
+                <name role="nrol:short">VfB Stuttgart</name>
             </team-metadata>
             <team-stats events-played="8">
                 <outcome-totals alignment-scope="events-all" events-played="8" standing-points="4"

--- a/3.0/examples/soccer-standings-g2-specific.xml
+++ b/3.0/examples/soccer-standings-g2-specific.xml
@@ -57,7 +57,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.198" alignment="none">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats events-played="7">
                             <outcome-totals alignment-scope="events-all" events-played="7"
@@ -80,7 +80,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.286" alignment="none">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats events-played="7">
                             <outcome-totals alignment-scope="events-all" events-played="7"
@@ -103,7 +103,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.358" alignment="none">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats events-played="7">
                             <outcome-totals alignment-scope="events-all" events-played="7"
@@ -126,7 +126,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.701" alignment="none">
                             <name role="nrol:full">Hertha BSC</name>
-                            <name part="nprt:common">Hertha BSC</name>
+                            <name role="nrol:short">Hertha BSC</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -150,7 +150,7 @@
                     <team>
                         <team-metadata key="vendteam:t.2743" alignment="none">
                             <name role="nrol:full">FC Ingolstadt 04</name>
-                            <name part="nprt:common">FC Ingolstadt 04</name>
+                            <name role="nrol:short">FC Ingolstadt 04</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -173,7 +173,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.1445" alignment="none">
                             <name role="nrol:full">1. FSV Mainz 05</name>
-                            <name part="nprt:common">1. FSV Mainz 05</name>
+                            <name role="nrol:short">1. FSV Mainz 05</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -196,7 +196,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.700" alignment="none">
                             <name role="nrol:full">VfL Wolfsburg</name>
-                            <name part="nprt:common">VfL Wolfsburg</name>
+                            <name role="nrol:short">VfL Wolfsburg</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -218,7 +218,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.353" alignment="none">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats events-played="7">
                             <outcome-totals alignment-scope="events-all" events-played="7"
@@ -240,7 +240,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.1457" alignment="none">
                             <name role="nrol:full">1. FC Köln</name>
-                            <name part="nprt:common">1. FC Köln</name>
+                            <name role="nrol:short">1. FC Köln</name>
                         </team-metadata>
                         <team-stats events-played="7">
                             <outcome-totals alignment-scope="events-all" events-played="7"
@@ -262,7 +262,7 @@
                     <team>
                         <team-metadata key="vendteam:t.1756" alignment="none">
                             <name role="nrol:full">SV Darmstadt 98</name>
-                            <name part="nprt:common">SV Darmstadt 98</name>
+                            <name role="nrol:short">SV Darmstadt 98</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -284,7 +284,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.326" alignment="none">
                             <name role="nrol:full">Hamburger SV</name>
-                            <name part="nprt:common">Hamburger SV</name>
+                            <name role="nrol:short">Hamburger SV</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -306,7 +306,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.926" alignment="none">
                             <name role="nrol:full">Eintracht Frankfurt</name>
-                            <name part="nprt:common">Eintracht Frankfurt</name>
+                            <name role="nrol:short">Eintracht Frankfurt</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -328,7 +328,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.310" alignment="none">
                             <name role="nrol:full">Borussia Mönchengladbach</name>
-                            <name part="nprt:common">Borussia Mönchengladbach</name>
+                            <name role="nrol:short">Borussia Mönchengladbach</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -350,7 +350,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.293" alignment="none">
                             <name role="nrol:full">SV Werder Bremen</name>
-                            <name part="nprt:common">SV Werder Bremen</name>
+                            <name role="nrol:short">SV Werder Bremen</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -372,7 +372,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.2074" alignment="none">
                             <name role="nrol:full">TSG 1899 Hoffenheim</name>
-                            <name part="nprt:common">TSG 1899 Hoffenheim</name>
+                            <name role="nrol:short">TSG 1899 Hoffenheim</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -394,7 +394,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.1452" alignment="none">
                             <name role="nrol:full">Hannover 96</name>
-                            <name part="nprt:common">Hannover 96</name>
+                            <name role="nrol:short">Hannover 96</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"
@@ -417,7 +417,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.1000" alignment="none">
                             <name role="nrol:full">FC Augsburg</name>
-                            <name part="nprt:common">FC Augsburg</name>
+                            <name role="nrol:short">FC Augsburg</name>
                         </team-metadata>
                         <team-stats events-played="7">
                             <outcome-totals alignment-scope="events-all" events-played="7"
@@ -440,7 +440,7 @@
                     <team>
                         <team-metadata key="vendteam:o.dfb.de-t.352" alignment="none">
                             <name role="nrol:full">VfB Stuttgart</name>
-                            <name part="nprt:common">VfB Stuttgart</name>
+                            <name role="nrol:short">VfB Stuttgart</name>
                         </team-metadata>
                         <team-stats events-played="8">
                             <outcome-totals alignment-scope="events-all" events-played="8"

--- a/3.0/examples/tennis_davis_cup_tournament.xml
+++ b/3.0/examples/tennis_davis_cup_tournament.xml
@@ -84,8 +84,8 @@
 
                                     <player id="p_1">
                                         <player-metadata>
-                                            <name role="nrol:first">Rafael</name>
-                                            <name role="nrol:last">Nadal</name>
+                                            <name part="nprt:given">Rafael</name>
+                                            <name part="nprt:family">Nadal</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><country><name>Spain</name></country></address>
@@ -188,8 +188,8 @@
 
                                     <player id="p_2">
                                         <player-metadata>
-                                            <name role="nrol:first">David</name>
-                                            <name role="nrol:last">Nalbandian</name>
+                                            <name part="nprt:given">David</name>
+                                            <name part="nprt:family">Nalbandian</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><country><name>Argentina</name></country></address>
@@ -362,8 +362,8 @@
                                         <player-metadata team-idref="DC_Serbia"
                                             date-of-birth="1986-02-10" gender="male"
                                             nationality="Serbian">
-                                            <name role="nrol:first">Viktor</name>
-                                            <name role="nrol:last">Troicki</name>
+                                            <name part="nprt:given">Viktor</name>
+                                            <name part="nprt:family">Troicki</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Belgrade</name></locality><country><name>Serbia</name></country></address>
@@ -391,8 +391,8 @@
                                     <player>
                                         <player-metadata date-of-birth="1982-01-01" gender="male"
                                             nationality="Argentinian">
-                                            <name role="nrol:first">David</name>
-                                            <name role="nrol:last">Nalbandian</name>
+                                            <name part="nprt:given">David</name>
+                                            <name part="nprt:family">Nalbandian</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Cordoba</name></locality><country><name>Argentina</name></country></address>
@@ -426,8 +426,8 @@
                                     <player>
                                         <player-metadata date-of-birth="1986-02-10" gender="male"
                                             nationality="Serbian">
-                                            <name role="nrol:first">Janko</name>
-                                            <name role="nrol:last">Tipsarevic</name>
+                                            <name part="nprt:given">Janko</name>
+                                            <name part="nprt:family">Tipsarevic</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Belgrade</name></locality><country><name>Servia</name></country></address>
@@ -451,8 +451,8 @@
                                     <player>
                                         <player-metadata date-of-birth="1988-09-23" gender="male"
                                             nationality="Argentinian">
-                                            <name role="nrol:first">Juan Martin</name>
-                                            <name role="nrol:last">Del Potro</name>
+                                            <name part="nprt:given">Juan Martin</name>
+                                            <name part="nprt:family">Del Potro</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Tandil</name></locality><country><name>Argentina</name></country></address>
@@ -504,8 +504,8 @@
                                             <player-metadata team-idref="DC_Serbia"
                                                 date-of-birth="1986-02-10" gender="male"
                                                 nationality="Serbian">
-                                                <name role="nrol:first">Viktor</name>
-                                                <name role="nrol:last">Troicki</name>
+                                                <name part="nprt:given">Viktor</name>
+                                                <name part="nprt:family">Troicki</name>
                                                 <home-location>
                                                   <POIDetails>
                                                   <address><locality><name>Belgrade</name></locality><country><name>Serbia</name></country></address>
@@ -521,8 +521,8 @@
                                             <player-metadata team-idref="DC_Serbia"
                                                 date-of-birth="1986-02-10" gender="male"
                                                 nationality="Serbian">
-                                                <name role="nrol:first">Nenad</name>
-                                                <name role="nrol:last">Zimonjic</name>
+                                                <name part="nprt:given">Nenad</name>
+                                                <name part="nprt:family">Zimonjic</name>
                                                 <home-location>
                                                   <POIDetails>
                                                   <address><locality><name>Belgrade</name></locality><country><name>Serbia</name></country></address>
@@ -555,8 +555,8 @@
                                             <player-metadata team-idref="DC_Argentina"
                                                 date-of-birth="1979-08-30" gender="male"
                                                 nationality="Serbian">
-                                                <name role="nrol:first">Juan Ignacio</name>
-                                                <name role="nrol:last">Chela</name>
+                                                <name part="nprt:given">Juan Ignacio</name>
+                                                <name part="nprt:family">Chela</name>
                                                 <home-location>
                                                   <POIDetails>
                                                   <address><locality><name>Buenos Aires</name></locality><country><name>Argentina</name></country></address>
@@ -572,8 +572,8 @@
                                             <player-metadata team-idref="DC_Argentina"
                                                 date-of-birth="1984-03-29" gender="male"
                                                 nationality="Serbian">
-                                                <name role="nrol:first">Juan</name>
-                                                <name role="nrol:last">Monaco</name>
+                                                <name part="nprt:given">Juan</name>
+                                                <name part="nprt:family">Monaco</name>
                                                 <home-location>
                                                   <POIDetails>
                                                   <address><locality><name>Buenos Aires</name></locality><country><name>Argentina</name></country></address>
@@ -601,8 +601,8 @@
                                         <player-metadata team-idref="DC_Serbia"
                                             date-of-birth="1987-05-22" gender="male"
                                             nationality="Serbian">
-                                            <name role="nrol:first">Novak</name>
-                                            <name role="nrol:last">Djokovic</name>
+                                            <name part="nprt:given">Novak</name>
+                                            <name part="nprt:family">Djokovic</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Belgrade</name></locality><country><name>Serbia</name></country></address>
@@ -625,8 +625,8 @@
                                     <player>
                                         <player-metadata date-of-birth="1988-09-23" gender="male"
                                             nationality="Argentinian">
-                                            <name role="nrol:first">Juan Martin</name>
-                                            <name role="nrol:last">Del Potro</name>
+                                            <name part="nprt:given">Juan Martin</name>
+                                            <name part="nprt:family">Del Potro</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Tandil</name></locality><country><name>Argentina</name></country></address>
@@ -658,8 +658,8 @@
                                     <player>
                                         <player-metadata date-of-birth="1986-02-10" gender="male"
                                             nationality="Serbian">
-                                            <name role="nrol:first">Janko</name>
-                                            <name role="nrol:last">Tipsarevic</name>
+                                            <name part="nprt:given">Janko</name>
+                                            <name part="nprt:family">Tipsarevic</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Belgrade</name></locality><country><name>Servia</name></country></address>
@@ -679,8 +679,8 @@
                                     <player>
                                         <player-metadata date-of-birth="1984-03-29" gender="male"
                                             nationality="Argentinian">
-                                            <name role="nrol:first">Juan</name>
-                                            <name role="nrol:last">Monaco</name>
+                                            <name part="nprt:given">Juan</name>
+                                            <name part="nprt:family">Monaco</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address><locality><name>Buenos Aires</name></locality><country><name>Argentina</name></country></address>

--- a/3.0/examples/tournament-cl-classic.xml
+++ b/3.0/examples/tournament-cl-classic.xml
@@ -23,19 +23,19 @@
         <tournament-metadata temporal-unit-type="spct:tournament" temporal-unit-value="vendor:2014"
             key="vendkey:CFBB5">
             <name role="nrol:full">Champions League</name>
-            <name part="nprt:common">Champions League</name>
+            <name role="nrol:short">Champions League</name>
         </tournament-metadata>
         <tournament-part>
             <tournament-part-metadata key="vendkey:CFBB52014S1" type="sptournamentphase:group" number="1"
                 maximum-subparts="8" minimum-subparts="8">
                 <name role="nrol:full">Champions League</name>
-                <name part="nprt:common">Champions League</name>
+                <name role="nrol:short">Champions League</name>
             </tournament-part-metadata>
             <tournament-part>
                 <tournament-part-metadata key="vendkey:CFBB52014S1R3" number="3" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782701" event-status="speventstatus:post-event"
@@ -44,7 +44,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2713">
                                 <name role="nrol:full">Estádio da Luz</name>
-                                <name part="nprt:common">Estádio da Luz</name>
+                                <name role="nrol:short">Estádio da Luz</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -58,7 +58,7 @@
                     <team id="EFBO782701-TFBB251">
                         <team-metadata key="vendteam:TFBB251" alignment="home">
                             <name role="nrol:full">Benfica</name>
-                            <name part="nprt:common">Benfica</name>
+                            <name role="nrol:short">Benfica</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -68,7 +68,7 @@
                     <team id="EFBO782701-TFBB1341">
                         <team-metadata key="vendteam:TFBB1341" alignment="away">
                             <name role="nrol:full">Zenit St Petersburg</name>
-                            <name part="nprt:common">Zenit St Petersburg</name>
+                            <name role="nrol:short">Zenit St Petersburg</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -101,7 +101,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1313">
                                 <name role="nrol:full">Stade Louis II</name>
-                                <name part="nprt:common">Stade Louis II</name>
+                                <name role="nrol:short">Stade Louis II</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -115,7 +115,7 @@
                     <team id="EFBO782702-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="home">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -128,7 +128,7 @@
                     <team id="EFBO782702-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="away">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -150,7 +150,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1368">
                                 <name role="nrol:full">BayArena</name>
-                                <name part="nprt:common">BayArena</name>
+                                <name role="nrol:short">BayArena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -164,7 +164,7 @@
                     <team id="EFBO782725-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="home">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -183,7 +183,7 @@
                     <team id="EFBO782725-TFBB251">
                         <team-metadata key="vendteam:TFBB251" alignment="away">
                             <name role="nrol:full">Benfica</name>
-                            <name part="nprt:common">Benfica</name>
+                            <name role="nrol:short">Benfica</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -223,7 +223,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2493">
                                 <name role="nrol:full">Petrovski Stadium</name>
-                                <name part="nprt:common">Petrovski Stadium</name>
+                                <name role="nrol:short">Petrovski Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -237,7 +237,7 @@
                     <team id="EFBO782726-TFBB1341">
                         <team-metadata key="vendteam:TFBB1341" alignment="home">
                             <name role="nrol:full">Zenit St Petersburg</name>
-                            <name part="nprt:common">Zenit St Petersburg</name>
+                            <name role="nrol:short">Zenit St Petersburg</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -247,7 +247,7 @@
                     <team id="EFBO782726-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="away">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -262,7 +262,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1368">
                                 <name role="nrol:full">BayArena</name>
-                                <name part="nprt:common">BayArena</name>
+                                <name role="nrol:short">BayArena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -276,7 +276,7 @@
                     <team id="EFBO782741-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="home">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -292,7 +292,7 @@
                     <team id="EFBO782741-TFBB1341">
                         <team-metadata key="vendteam:TFBB1341" alignment="away">
                             <name role="nrol:full">Zenit St Petersburg</name>
-                            <name part="nprt:common">Zenit St Petersburg</name>
+                            <name role="nrol:short">Zenit St Petersburg</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -319,7 +319,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1313">
                                 <name role="nrol:full">Stade Louis II</name>
-                                <name part="nprt:common">Stade Louis II</name>
+                                <name role="nrol:short">Stade Louis II</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -333,7 +333,7 @@
                     <team id="EFBO782742-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="home">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -343,7 +343,7 @@
                     <team id="EFBO782742-TFBB251">
                         <team-metadata key="vendteam:TFBB251" alignment="away">
                             <name role="nrol:full">Benfica</name>
-                            <name part="nprt:common">Benfica</name>
+                            <name role="nrol:short">Benfica</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -358,7 +358,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2713">
                                 <name role="nrol:full">Estádio da Luz</name>
-                                <name part="nprt:common">Estádio da Luz</name>
+                                <name role="nrol:short">Estádio da Luz</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -372,7 +372,7 @@
                     <team id="EFBO782749-TFBB251">
                         <team-metadata key="vendteam:TFBB251" alignment="home">
                             <name role="nrol:full">Benfica</name>
-                            <name part="nprt:common">Benfica</name>
+                            <name role="nrol:short">Benfica</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -385,7 +385,7 @@
                     <team id="EFBO782749-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="away">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -407,7 +407,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2493">
                                 <name role="nrol:full">Petrovski Stadium</name>
-                                <name part="nprt:common">Petrovski Stadium</name>
+                                <name role="nrol:short">Petrovski Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -421,7 +421,7 @@
                     <team id="EFBO782750-TFBB1341">
                         <team-metadata key="vendteam:TFBB1341" alignment="home">
                             <name role="nrol:full">Zenit St Petersburg</name>
-                            <name part="nprt:common">Zenit St Petersburg</name>
+                            <name role="nrol:short">Zenit St Petersburg</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -434,7 +434,7 @@
                     <team id="EFBO782750-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="away">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -469,7 +469,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1368">
                                 <name role="nrol:full">BayArena</name>
-                                <name part="nprt:common">BayArena</name>
+                                <name role="nrol:short">BayArena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -483,7 +483,7 @@
                     <team id="EFBO782773-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="home">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -493,7 +493,7 @@
                     <team id="EFBO782773-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="away">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -518,7 +518,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2493">
                                 <name role="nrol:full">Petrovski Stadium</name>
-                                <name part="nprt:common">Petrovski Stadium</name>
+                                <name role="nrol:short">Petrovski Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -532,7 +532,7 @@
                     <team id="EFBO782774-TFBB1341">
                         <team-metadata key="vendteam:TFBB1341" alignment="home">
                             <name role="nrol:full">Zenit St Petersburg</name>
-                            <name part="nprt:common">Zenit St Petersburg</name>
+                            <name role="nrol:short">Zenit St Petersburg</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -545,7 +545,7 @@
                     <team id="EFBO782774-TFBB251">
                         <team-metadata key="vendteam:TFBB251" alignment="away">
                             <name role="nrol:full">Benfica</name>
-                            <name part="nprt:common">Benfica</name>
+                            <name role="nrol:short">Benfica</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -567,7 +567,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2713">
                                 <name role="nrol:full">Estádio da Luz</name>
-                                <name part="nprt:common">Estádio da Luz</name>
+                                <name role="nrol:short">Estádio da Luz</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -581,7 +581,7 @@
                     <team id="EFBO782781-TFBB251">
                         <team-metadata key="vendteam:TFBB251" alignment="home">
                             <name role="nrol:full">Benfica</name>
-                            <name part="nprt:common">Benfica</name>
+                            <name role="nrol:short">Benfica</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -591,7 +591,7 @@
                     <team id="EFBO782781-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="away">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -606,7 +606,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1313">
                                 <name role="nrol:full">Stade Louis II</name>
-                                <name part="nprt:common">Stade Louis II</name>
+                                <name role="nrol:short">Stade Louis II</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -620,7 +620,7 @@
                     <team id="EFBO782782-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="home">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -636,7 +636,7 @@
                     <team id="EFBO782782-TFBB1341">
                         <team-metadata key="vendteam:TFBB1341" alignment="away">
                             <name role="nrol:full">Zenit St Petersburg</name>
-                            <name part="nprt:common">Zenit St Petersburg</name>
+                            <name role="nrol:short">Zenit St Petersburg</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -661,7 +661,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R4" number="4" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782703" event-status="speventstatus:post-event"
@@ -670,7 +670,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1369">
                                 <name role="nrol:full">Signal Iduna Park</name>
-                                <name part="nprt:common">Signal Iduna Park</name>
+                                <name role="nrol:short">Signal Iduna Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -684,7 +684,7 @@
                     <team id="EFBO782703-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="home">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -700,7 +700,7 @@
                     <team id="EFBO782703-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="away">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -727,7 +727,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7241">
                                 <name role="nrol:full">Türk Telekom Arena</name>
-                                <name part="nprt:common">Türk Telekom Arena</name>
+                                <name role="nrol:short">Türk Telekom Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -741,7 +741,7 @@
                     <team id="EFBO782704-TFBB208">
                         <team-metadata key="vendteam:TFBB208" alignment="home">
                             <name role="nrol:full">Galatasaray</name>
-                            <name part="nprt:common">Galatasaray</name>
+                            <name role="nrol:short">Galatasaray</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -754,7 +754,7 @@
                     <team id="EFBO782704-TFBB241">
                         <team-metadata key="vendteam:TFBB241" alignment="away">
                             <name role="nrol:full">RSC Anderlecht</name>
-                            <name part="nprt:common">RSC Anderlecht</name>
+                            <name role="nrol:short">RSC Anderlecht</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -784,7 +784,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3250">
                                 <name role="nrol:full">Emirates Stadium</name>
-                                <name part="nprt:common">Emirates Stadium</name>
+                                <name role="nrol:short">Emirates Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -798,7 +798,7 @@
                     <team id="EFBO782727-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="home">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -814,7 +814,7 @@
                     <team id="EFBO782727-TFBB208">
                         <team-metadata key="vendteam:TFBB208" alignment="away">
                             <name role="nrol:full">Galatasaray</name>
-                            <name part="nprt:common">Galatasaray</name>
+                            <name role="nrol:short">Galatasaray</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -859,7 +859,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2113">
                                 <name role="nrol:full">Constant Vanden Stockstadion</name>
-                                <name part="nprt:common">Constant Vanden Stockstadion</name>
+                                <name role="nrol:short">Constant Vanden Stockstadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -873,7 +873,7 @@
                     <team id="EFBO782728-TFBB241">
                         <team-metadata key="vendteam:TFBB241" alignment="home">
                             <name role="nrol:full">RSC Anderlecht</name>
-                            <name part="nprt:common">RSC Anderlecht</name>
+                            <name role="nrol:short">RSC Anderlecht</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -883,7 +883,7 @@
                     <team id="EFBO782728-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="away">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -921,7 +921,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7241">
                                 <name role="nrol:full">Türk Telekom Arena</name>
-                                <name part="nprt:common">Türk Telekom Arena</name>
+                                <name role="nrol:short">Türk Telekom Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -935,7 +935,7 @@
                     <team id="EFBO782743-TFBB208">
                         <team-metadata key="vendteam:TFBB208" alignment="home">
                             <name role="nrol:full">Galatasaray</name>
-                            <name part="nprt:common">Galatasaray</name>
+                            <name role="nrol:short">Galatasaray</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -945,7 +945,7 @@
                     <team id="EFBO782743-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="away">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -991,7 +991,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2113">
                                 <name role="nrol:full">Constant Vanden Stockstadion</name>
-                                <name part="nprt:common">Constant Vanden Stockstadion</name>
+                                <name role="nrol:short">Constant Vanden Stockstadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1005,7 +1005,7 @@
                     <team id="EFBO782744-TFBB241">
                         <team-metadata key="vendteam:TFBB241" alignment="home">
                             <name role="nrol:full">RSC Anderlecht</name>
-                            <name part="nprt:common">RSC Anderlecht</name>
+                            <name role="nrol:short">RSC Anderlecht</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1018,7 +1018,7 @@
                     <team id="EFBO782744-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="away">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -1056,7 +1056,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3250">
                                 <name role="nrol:full">Emirates Stadium</name>
-                                <name part="nprt:common">Emirates Stadium</name>
+                                <name role="nrol:short">Emirates Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1070,7 +1070,7 @@
                     <team id="EFBO782751-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="home">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="3" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="2"/>
@@ -1089,7 +1089,7 @@
                     <team id="EFBO782751-TFBB241">
                         <team-metadata key="vendteam:TFBB241" alignment="away">
                             <name role="nrol:full">RSC Anderlecht</name>
-                            <name part="nprt:common">RSC Anderlecht</name>
+                            <name role="nrol:short">RSC Anderlecht</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="3" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -1142,7 +1142,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1369">
                                 <name role="nrol:full">Signal Iduna Park</name>
-                                <name part="nprt:common">Signal Iduna Park</name>
+                                <name role="nrol:short">Signal Iduna Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1156,7 +1156,7 @@
                     <team id="EFBO782752-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="home">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1178,7 +1178,7 @@
                     <team id="EFBO782752-TFBB208">
                         <team-metadata key="vendteam:TFBB208" alignment="away">
                             <name role="nrol:full">Galatasaray</name>
-                            <name part="nprt:common">Galatasaray</name>
+                            <name role="nrol:short">Galatasaray</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1223,7 +1223,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3250">
                                 <name role="nrol:full">Emirates Stadium</name>
-                                <name part="nprt:common">Emirates Stadium</name>
+                                <name role="nrol:short">Emirates Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1237,7 +1237,7 @@
                     <team id="EFBO782775-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="home">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1253,7 +1253,7 @@
                     <team id="EFBO782775-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="away">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1280,7 +1280,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2113">
                                 <name role="nrol:full">Constant Vanden Stockstadion</name>
-                                <name part="nprt:common">Constant Vanden Stockstadion</name>
+                                <name role="nrol:short">Constant Vanden Stockstadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1294,7 +1294,7 @@
                     <team id="EFBO782776-TFBB241">
                         <team-metadata key="vendteam:TFBB241" alignment="home">
                             <name role="nrol:full">RSC Anderlecht</name>
-                            <name part="nprt:common">RSC Anderlecht</name>
+                            <name role="nrol:short">RSC Anderlecht</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1307,7 +1307,7 @@
                     <team id="EFBO782776-TFBB208">
                         <team-metadata key="vendteam:TFBB208" alignment="away">
                             <name role="nrol:full">Galatasaray</name>
-                            <name part="nprt:common">Galatasaray</name>
+                            <name role="nrol:short">Galatasaray</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1334,7 +1334,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1369">
                                 <name role="nrol:full">Signal Iduna Park</name>
-                                <name part="nprt:common">Signal Iduna Park</name>
+                                <name role="nrol:short">Signal Iduna Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1348,7 +1348,7 @@
                     <team id="EFBO782783-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="home">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -1361,7 +1361,7 @@
                     <team id="EFBO782783-TFBB241">
                         <team-metadata key="vendteam:TFBB241" alignment="away">
                             <name role="nrol:full">RSC Anderlecht</name>
-                            <name part="nprt:common">RSC Anderlecht</name>
+                            <name role="nrol:short">RSC Anderlecht</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -1391,7 +1391,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7241">
                                 <name role="nrol:full">Türk Telekom Arena</name>
-                                <name part="nprt:common">Türk Telekom Arena</name>
+                                <name role="nrol:short">Türk Telekom Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1405,7 +1405,7 @@
                     <team id="EFBO782784-TFBB208">
                         <team-metadata key="vendteam:TFBB208" alignment="home">
                             <name role="nrol:full">Galatasaray</name>
-                            <name part="nprt:common">Galatasaray</name>
+                            <name role="nrol:short">Galatasaray</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1418,7 +1418,7 @@
                     <team id="EFBO782784-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="away">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -1464,7 +1464,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R1" number="1" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782697" event-status="speventstatus:post-event"
@@ -1473,7 +1473,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7598">
                                 <name role="nrol:full">Juventus Stadium</name>
-                                <name part="nprt:common">Juventus Stadium</name>
+                                <name role="nrol:short">Juventus Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1487,7 +1487,7 @@
                     <team id="EFBO782697-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -1500,7 +1500,7 @@
                     <team id="EFBO782697-TFBB993">
                         <team-metadata key="vendteam:TFBB993" alignment="away">
                             <name role="nrol:full">Malmö FF</name>
-                            <name part="nprt:common">Malmö FF</name>
+                            <name role="nrol:short">Malmö FF</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1527,7 +1527,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3063">
                                 <name role="nrol:full">Georgios Karaiskakis Stadium</name>
-                                <name part="nprt:common">Georgios Karaiskakis Stadium</name>
+                                <name role="nrol:short">Georgios Karaiskakis Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1541,7 +1541,7 @@
                     <team id="EFBO782698-TFBB202">
                         <team-metadata key="vendteam:TFBB202" alignment="home">
                             <name role="nrol:full">Olympiakos</name>
-                            <name part="nprt:common">Olympiakos</name>
+                            <name role="nrol:short">Olympiakos</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -1560,7 +1560,7 @@
                     <team id="EFBO782698-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="away">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -1608,7 +1608,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2599">
                                 <name role="nrol:full">Vicente Calderón</name>
-                                <name part="nprt:common">Vicente Calderón</name>
+                                <name role="nrol:short">Vicente Calderón</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1622,7 +1622,7 @@
                     <team id="EFBO782721-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="home">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -1635,7 +1635,7 @@
                     <team id="EFBO782721-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="away">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1657,7 +1657,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB8829">
                                 <name role="nrol:full">Swedbank Stadion</name>
-                                <name part="nprt:common">Swedbank Stadion</name>
+                                <name role="nrol:short">Swedbank Stadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1671,7 +1671,7 @@
                     <team id="EFBO782722-TFBB993">
                         <team-metadata key="vendteam:TFBB993" alignment="home">
                             <name role="nrol:full">Malmö FF</name>
-                            <name part="nprt:common">Malmö FF</name>
+                            <name role="nrol:short">Malmö FF</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1684,7 +1684,7 @@
                     <team id="EFBO782722-TFBB202">
                         <team-metadata key="vendteam:TFBB202" alignment="away">
                             <name role="nrol:full">Olympiakos</name>
-                            <name part="nprt:common">Olympiakos</name>
+                            <name role="nrol:short">Olympiakos</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1711,7 +1711,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2599">
                                 <name role="nrol:full">Vicente Calderón</name>
-                                <name part="nprt:common">Vicente Calderón</name>
+                                <name role="nrol:short">Vicente Calderón</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1725,7 +1725,7 @@
                     <team id="EFBO782737-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="home">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="5" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -1750,7 +1750,7 @@
                     <team id="EFBO782737-TFBB993">
                         <team-metadata key="vendteam:TFBB993" alignment="away">
                             <name role="nrol:full">Malmö FF</name>
-                            <name part="nprt:common">Malmö FF</name>
+                            <name role="nrol:short">Malmö FF</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="5" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1792,7 +1792,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3063">
                                 <name role="nrol:full">Georgios Karaiskakis Stadium</name>
-                                <name part="nprt:common">Georgios Karaiskakis Stadium</name>
+                                <name role="nrol:short">Georgios Karaiskakis Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1806,7 +1806,7 @@
                     <team id="EFBO782738-TFBB202">
                         <team-metadata key="vendteam:TFBB202" alignment="home">
                             <name role="nrol:full">Olympiakos</name>
-                            <name part="nprt:common">Olympiakos</name>
+                            <name role="nrol:short">Olympiakos</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1819,7 +1819,7 @@
                     <team id="EFBO782738-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="away">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1841,7 +1841,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7598">
                                 <name role="nrol:full">Juventus Stadium</name>
-                                <name part="nprt:common">Juventus Stadium</name>
+                                <name role="nrol:short">Juventus Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1855,7 +1855,7 @@
                     <team id="EFBO782745-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1874,7 +1874,7 @@
                     <team id="EFBO782745-TFBB202">
                         <team-metadata key="vendteam:TFBB202" alignment="away">
                             <name role="nrol:full">Olympiakos</name>
-                            <name part="nprt:common">Olympiakos</name>
+                            <name role="nrol:short">Olympiakos</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -1922,7 +1922,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB8829">
                                 <name role="nrol:full">Swedbank Stadion</name>
-                                <name part="nprt:common">Swedbank Stadion</name>
+                                <name role="nrol:short">Swedbank Stadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1936,7 +1936,7 @@
                     <team id="EFBO782746-TFBB993">
                         <team-metadata key="vendteam:TFBB993" alignment="home">
                             <name role="nrol:full">Malmö FF</name>
-                            <name part="nprt:common">Malmö FF</name>
+                            <name role="nrol:short">Malmö FF</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -1946,7 +1946,7 @@
                     <team id="EFBO782746-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="away">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -1979,7 +1979,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2599">
                                 <name role="nrol:full">Vicente Calderón</name>
-                                <name part="nprt:common">Vicente Calderón</name>
+                                <name role="nrol:short">Vicente Calderón</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -1993,7 +1993,7 @@
                     <team id="EFBO782769-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="home">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -2009,7 +2009,7 @@
                     <team id="EFBO782769-TFBB202">
                         <team-metadata key="vendteam:TFBB202" alignment="away">
                             <name role="nrol:full">Olympiakos</name>
-                            <name part="nprt:common">Olympiakos</name>
+                            <name role="nrol:short">Olympiakos</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2046,7 +2046,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB8829">
                                 <name role="nrol:full">Swedbank Stadion</name>
-                                <name part="nprt:common">Swedbank Stadion</name>
+                                <name role="nrol:short">Swedbank Stadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2060,7 +2060,7 @@
                     <team id="EFBO782770-TFBB993">
                         <team-metadata key="vendteam:TFBB993" alignment="home">
                             <name role="nrol:full">Malmö FF</name>
-                            <name part="nprt:common">Malmö FF</name>
+                            <name role="nrol:short">Malmö FF</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2070,7 +2070,7 @@
                     <team id="EFBO782770-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="away">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -2103,7 +2103,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7598">
                                 <name role="nrol:full">Juventus Stadium</name>
-                                <name part="nprt:common">Juventus Stadium</name>
+                                <name role="nrol:short">Juventus Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2117,7 +2117,7 @@
                     <team id="EFBO782777-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -2127,7 +2127,7 @@
                     <team id="EFBO782777-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="away">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -2142,7 +2142,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3063">
                                 <name role="nrol:full">Georgios Karaiskakis Stadium</name>
-                                <name part="nprt:common">Georgios Karaiskakis Stadium</name>
+                                <name role="nrol:short">Georgios Karaiskakis Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2156,7 +2156,7 @@
                     <team id="EFBO782778-TFBB202">
                         <team-metadata key="vendteam:TFBB202" alignment="home">
                             <name role="nrol:full">Olympiakos</name>
-                            <name part="nprt:common">Olympiakos</name>
+                            <name role="nrol:short">Olympiakos</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -2178,7 +2178,7 @@
                     <team id="EFBO782778-TFBB993">
                         <team-metadata key="vendteam:TFBB993" alignment="away">
                             <name role="nrol:full">Malmö FF</name>
-                            <name part="nprt:common">Malmö FF</name>
+                            <name role="nrol:short">Malmö FF</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2229,7 +2229,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R2" number="2" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782699" event-status="speventstatus:post-event"
@@ -2238,7 +2238,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB39">
                                 <name role="nrol:full">Anfield</name>
-                                <name part="nprt:common">Anfield</name>
+                                <name role="nrol:short">Anfield</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2252,7 +2252,7 @@
                     <team id="EFBO782699-TFBB14">
                         <team-metadata key="vendteam:TFBB14" alignment="home">
                             <name role="nrol:full">Liverpool</name>
-                            <name part="nprt:common">Liverpool</name>
+                            <name role="nrol:short">Liverpool</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -2268,7 +2268,7 @@
                     <team id="EFBO782699-TFBB6128">
                         <team-metadata key="vendteam:TFBB6128" alignment="away">
                             <name role="nrol:full">Ludogorets Razgrad</name>
-                            <name part="nprt:common">Ludogorets Razgrad</name>
+                            <name role="nrol:short">Ludogorets Razgrad</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2303,7 +2303,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1360">
                                 <name role="nrol:full">Santiago Bernabéu</name>
-                                <name part="nprt:common">Santiago Bernabéu</name>
+                                <name role="nrol:short">Santiago Bernabéu</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2317,7 +2317,7 @@
                     <team id="EFBO782700-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="home">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="5" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="4"/>
@@ -2342,7 +2342,7 @@
                     <team id="EFBO782700-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="away">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="5" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -2392,7 +2392,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2208">
                                 <name role="nrol:full">St Jakob-Park</name>
-                                <name part="nprt:common">St Jakob-Park</name>
+                                <name role="nrol:short">St Jakob-Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2406,7 +2406,7 @@
                     <team id="EFBO782723-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="home">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -2419,7 +2419,7 @@
                     <team id="EFBO782723-TFBB14">
                         <team-metadata key="vendteam:TFBB14" alignment="away">
                             <name role="nrol:full">Liverpool</name>
-                            <name part="nprt:common">Liverpool</name>
+                            <name role="nrol:short">Liverpool</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2441,7 +2441,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2995">
                                 <name role="nrol:full">Vasil Levski National Stadium</name>
-                                <name part="nprt:common">Vasil Levski National Stadium</name>
+                                <name role="nrol:short">Vasil Levski National Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2455,7 +2455,7 @@
                     <team id="EFBO782724-TFBB6128">
                         <team-metadata key="vendteam:TFBB6128" alignment="home">
                             <name role="nrol:full">Ludogorets Razgrad</name>
-                            <name part="nprt:common">Ludogorets Razgrad</name>
+                            <name role="nrol:short">Ludogorets Razgrad</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -2468,7 +2468,7 @@
                     <team id="EFBO782724-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="away">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -2506,7 +2506,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB39">
                                 <name role="nrol:full">Anfield</name>
-                                <name part="nprt:common">Anfield</name>
+                                <name role="nrol:short">Anfield</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2520,7 +2520,7 @@
                     <team id="EFBO782739-TFBB14">
                         <team-metadata key="vendteam:TFBB14" alignment="home">
                             <name role="nrol:full">Liverpool</name>
-                            <name part="nprt:common">Liverpool</name>
+                            <name role="nrol:short">Liverpool</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2530,7 +2530,7 @@
                     <team id="EFBO782739-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="away">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -2568,7 +2568,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2995">
                                 <name role="nrol:full">Vasil Levski National Stadium</name>
-                                <name part="nprt:common">Vasil Levski National Stadium</name>
+                                <name role="nrol:short">Vasil Levski National Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2582,7 +2582,7 @@
                     <team id="EFBO782740-TFBB6128">
                         <team-metadata key="vendteam:TFBB6128" alignment="home">
                             <name role="nrol:full">Ludogorets Razgrad</name>
-                            <name part="nprt:common">Ludogorets Razgrad</name>
+                            <name role="nrol:short">Ludogorets Razgrad</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -2595,7 +2595,7 @@
                     <team id="EFBO782740-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="away">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2617,7 +2617,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2208">
                                 <name role="nrol:full">St Jakob-Park</name>
-                                <name part="nprt:common">St Jakob-Park</name>
+                                <name role="nrol:short">St Jakob-Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2631,7 +2631,7 @@
                     <team id="EFBO782747-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="home">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -2653,7 +2653,7 @@
                     <team id="EFBO782747-TFBB6128">
                         <team-metadata key="vendteam:TFBB6128" alignment="away">
                             <name role="nrol:full">Ludogorets Razgrad</name>
-                            <name part="nprt:common">Ludogorets Razgrad</name>
+                            <name role="nrol:short">Ludogorets Razgrad</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2690,7 +2690,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1360">
                                 <name role="nrol:full">Santiago Bernabéu</name>
-                                <name part="nprt:common">Santiago Bernabéu</name>
+                                <name role="nrol:short">Santiago Bernabéu</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2704,7 +2704,7 @@
                     <team id="EFBO782748-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="home">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -2717,7 +2717,7 @@
                     <team id="EFBO782748-TFBB14">
                         <team-metadata key="vendteam:TFBB14" alignment="away">
                             <name role="nrol:full">Liverpool</name>
-                            <name part="nprt:common">Liverpool</name>
+                            <name role="nrol:short">Liverpool</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2739,7 +2739,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2208">
                                 <name role="nrol:full">St Jakob-Park</name>
-                                <name part="nprt:common">St Jakob-Park</name>
+                                <name role="nrol:short">St Jakob-Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2753,7 +2753,7 @@
                     <team id="EFBO782771-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="home">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2763,7 +2763,7 @@
                     <team id="EFBO782771-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="away">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -2788,7 +2788,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2995">
                                 <name role="nrol:full">Vasil Levski National Stadium</name>
-                                <name part="nprt:common">Vasil Levski National Stadium</name>
+                                <name role="nrol:short">Vasil Levski National Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2802,7 +2802,7 @@
                     <team id="EFBO782772-TFBB6128">
                         <team-metadata key="vendteam:TFBB6128" alignment="home">
                             <name role="nrol:full">Ludogorets Razgrad</name>
-                            <name part="nprt:common">Ludogorets Razgrad</name>
+                            <name role="nrol:short">Ludogorets Razgrad</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -2818,7 +2818,7 @@
                     <team id="EFBO782772-TFBB14">
                         <team-metadata key="vendteam:TFBB14" alignment="away">
                             <name role="nrol:full">Liverpool</name>
-                            <name part="nprt:common">Liverpool</name>
+                            <name role="nrol:short">Liverpool</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="2"/>
@@ -2861,7 +2861,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB39">
                                 <name role="nrol:full">Anfield</name>
-                                <name part="nprt:common">Anfield</name>
+                                <name role="nrol:short">Anfield</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2875,7 +2875,7 @@
                     <team id="EFBO782779-TFBB14">
                         <team-metadata key="vendteam:TFBB14" alignment="home">
                             <name role="nrol:full">Liverpool</name>
-                            <name part="nprt:common">Liverpool</name>
+                            <name role="nrol:short">Liverpool</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -2888,7 +2888,7 @@
                     <team id="EFBO782779-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="away">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -2918,7 +2918,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1360">
                                 <name role="nrol:full">Santiago Bernabéu</name>
-                                <name part="nprt:common">Santiago Bernabéu</name>
+                                <name role="nrol:short">Santiago Bernabéu</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -2932,7 +2932,7 @@
                     <team id="EFBO782780-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="home">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -2954,7 +2954,7 @@
                     <team id="EFBO782780-TFBB6128">
                         <team-metadata key="vendteam:TFBB6128" alignment="away">
                             <name role="nrol:full">Ludogorets Razgrad</name>
-                            <name part="nprt:common">Ludogorets Razgrad</name>
+                            <name role="nrol:short">Ludogorets Razgrad</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -2989,7 +2989,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R6" number="6" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782707" event-status="speventstatus:post-event"
@@ -2998,7 +2998,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB112">
                                 <name role="nrol:full">Amsterdam ArenA</name>
-                                <name part="nprt:common">Amsterdam ArenA</name>
+                                <name role="nrol:short">Amsterdam ArenA</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3012,7 +3012,7 @@
                     <team id="EFBO782707-TFBB215">
                         <team-metadata key="vendteam:TFBB215" alignment="home">
                             <name role="nrol:full">Ajax</name>
-                            <name part="nprt:common">Ajax</name>
+                            <name role="nrol:short">Ajax</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -3025,7 +3025,7 @@
                     <team id="EFBO782707-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="away">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -3055,7 +3055,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1349">
                                 <name role="nrol:full">Camp Nou</name>
-                                <name part="nprt:common">Camp Nou</name>
+                                <name role="nrol:short">Camp Nou</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3069,7 +3069,7 @@
                     <team id="EFBO782708-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="home">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -3082,7 +3082,7 @@
                     <team id="EFBO782708-TFBB479">
                         <team-metadata key="vendteam:TFBB479" alignment="away">
                             <name role="nrol:full">APOEL Nicosia</name>
-                            <name part="nprt:common">APOEL Nicosia</name>
+                            <name role="nrol:short">APOEL Nicosia</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3104,7 +3104,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2861">
                                 <name role="nrol:full">GSP Stadium</name>
-                                <name part="nprt:common">GSP Stadium</name>
+                                <name role="nrol:short">GSP Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3118,7 +3118,7 @@
                     <team id="EFBO782715-TFBB479">
                         <team-metadata key="vendteam:TFBB479" alignment="home">
                             <name role="nrol:full">APOEL Nicosia</name>
-                            <name part="nprt:common">APOEL Nicosia</name>
+                            <name role="nrol:short">APOEL Nicosia</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -3131,7 +3131,7 @@
                     <team id="EFBO782715-TFBB215">
                         <team-metadata key="vendteam:TFBB215" alignment="away">
                             <name role="nrol:full">Ajax</name>
-                            <name part="nprt:common">Ajax</name>
+                            <name role="nrol:short">Ajax</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -3161,7 +3161,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1311">
                                 <name role="nrol:full">Parc des Princes</name>
-                                <name part="nprt:common">Parc des Princes</name>
+                                <name role="nrol:short">Parc des Princes</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3175,7 +3175,7 @@
                     <team id="EFBO782716-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="home">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -3194,7 +3194,7 @@
                     <team id="EFBO782716-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -3242,7 +3242,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2861">
                                 <name role="nrol:full">GSP Stadium</name>
-                                <name part="nprt:common">GSP Stadium</name>
+                                <name role="nrol:short">GSP Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3256,7 +3256,7 @@
                     <team id="EFBO782731-TFBB479">
                         <team-metadata key="vendteam:TFBB479" alignment="home">
                             <name role="nrol:full">APOEL Nicosia</name>
-                            <name part="nprt:common">APOEL Nicosia</name>
+                            <name role="nrol:short">APOEL Nicosia</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3266,7 +3266,7 @@
                     <team id="EFBO782731-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="away">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -3291,7 +3291,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1349">
                                 <name role="nrol:full">Camp Nou</name>
-                                <name part="nprt:common">Camp Nou</name>
+                                <name role="nrol:short">Camp Nou</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3305,7 +3305,7 @@
                     <team id="EFBO782732-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="home">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -3324,7 +3324,7 @@
                     <team id="EFBO782732-TFBB215">
                         <team-metadata key="vendteam:TFBB215" alignment="away">
                             <name role="nrol:full">Ajax</name>
-                            <name part="nprt:common">Ajax</name>
+                            <name role="nrol:short">Ajax</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3364,7 +3364,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB112">
                                 <name role="nrol:full">Amsterdam ArenA</name>
-                                <name part="nprt:common">Amsterdam ArenA</name>
+                                <name role="nrol:short">Amsterdam ArenA</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3378,7 +3378,7 @@
                     <team id="EFBO782755-TFBB215">
                         <team-metadata key="vendteam:TFBB215" alignment="home">
                             <name role="nrol:full">Ajax</name>
-                            <name part="nprt:common">Ajax</name>
+                            <name role="nrol:short">Ajax</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3388,7 +3388,7 @@
                     <team id="EFBO782755-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -3418,7 +3418,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1311">
                                 <name role="nrol:full">Parc des Princes</name>
-                                <name part="nprt:common">Parc des Princes</name>
+                                <name role="nrol:short">Parc des Princes</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3432,7 +3432,7 @@
                     <team id="EFBO782756-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="home">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -3445,7 +3445,7 @@
                     <team id="EFBO782756-TFBB479">
                         <team-metadata key="vendteam:TFBB479" alignment="away">
                             <name role="nrol:full">APOEL Nicosia</name>
-                            <name part="nprt:common">APOEL Nicosia</name>
+                            <name role="nrol:short">APOEL Nicosia</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3467,7 +3467,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2861">
                                 <name role="nrol:full">GSP Stadium</name>
-                                <name part="nprt:common">GSP Stadium</name>
+                                <name role="nrol:short">GSP Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3481,7 +3481,7 @@
                     <team id="EFBO782763-TFBB479">
                         <team-metadata key="vendteam:TFBB479" alignment="home">
                             <name role="nrol:full">APOEL Nicosia</name>
-                            <name part="nprt:common">APOEL Nicosia</name>
+                            <name role="nrol:short">APOEL Nicosia</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3491,7 +3491,7 @@
                     <team id="EFBO782763-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -3534,7 +3534,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1311">
                                 <name role="nrol:full">Parc des Princes</name>
-                                <name part="nprt:common">Parc des Princes</name>
+                                <name role="nrol:short">Parc des Princes</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3548,7 +3548,7 @@
                     <team id="EFBO782764-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="home">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -3564,7 +3564,7 @@
                     <team id="EFBO782764-TFBB215">
                         <team-metadata key="vendteam:TFBB215" alignment="away">
                             <name role="nrol:full">Ajax</name>
-                            <name part="nprt:common">Ajax</name>
+                            <name role="nrol:short">Ajax</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3604,7 +3604,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB112">
                                 <name role="nrol:full">Amsterdam ArenA</name>
-                                <name part="nprt:common">Amsterdam ArenA</name>
+                                <name role="nrol:short">Amsterdam ArenA</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3618,7 +3618,7 @@
                     <team id="EFBO782787-TFBB215">
                         <team-metadata key="vendteam:TFBB215" alignment="home">
                             <name role="nrol:full">Ajax</name>
-                            <name part="nprt:common">Ajax</name>
+                            <name role="nrol:short">Ajax</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -3637,7 +3637,7 @@
                     <team id="EFBO782787-TFBB479">
                         <team-metadata key="vendteam:TFBB479" alignment="away">
                             <name role="nrol:full">APOEL Nicosia</name>
-                            <name part="nprt:common">APOEL Nicosia</name>
+                            <name role="nrol:short">APOEL Nicosia</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3674,7 +3674,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1349">
                                 <name role="nrol:full">Camp Nou</name>
-                                <name part="nprt:common">Camp Nou</name>
+                                <name role="nrol:short">Camp Nou</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3688,7 +3688,7 @@
                     <team id="EFBO782788-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="home">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -3707,7 +3707,7 @@
                     <team id="EFBO782788-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="away">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -3745,7 +3745,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R8" number="8" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782711" event-status="speventstatus:post-event"
@@ -3754,7 +3754,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB8973">
                                 <name role="nrol:full">San Mamés</name>
-                                <name part="nprt:common">San Mamés</name>
+                                <name role="nrol:short">San Mamés</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3768,7 +3768,7 @@
                     <team id="EFBO782711-TFBB174">
                         <team-metadata key="vendteam:TFBB174" alignment="home">
                             <name role="nrol:full">Athletic Club</name>
-                            <name part="nprt:common">Athletic Club</name>
+                            <name role="nrol:short">Athletic Club</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -3778,7 +3778,7 @@
                     <team id="EFBO782711-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="away">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -3793,7 +3793,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2710">
                                 <name role="nrol:full">Estadio do Dragão</name>
-                                <name part="nprt:common">Estadio do Dragão</name>
+                                <name role="nrol:short">Estadio do Dragão</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3807,7 +3807,7 @@
                     <team id="EFBO782712-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="home">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="6" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -3829,7 +3829,7 @@
                     <team id="EFBO782712-TFBB2155">
                         <team-metadata key="vendteam:TFBB2155" alignment="away">
                             <name role="nrol:full">BATE Borisov</name>
-                            <name part="nprt:common">BATE Borisov</name>
+                            <name role="nrol:short">BATE Borisov</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="6" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -3876,7 +3876,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB9764">
                                 <name role="nrol:full">Borisov Arena</name>
-                                <name part="nprt:common">Borisov Arena</name>
+                                <name role="nrol:short">Borisov Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3890,7 +3890,7 @@
                     <team id="EFBO782719-TFBB2155">
                         <team-metadata key="vendteam:TFBB2155" alignment="home">
                             <name role="nrol:full">BATE Borisov</name>
-                            <name part="nprt:common">BATE Borisov</name>
+                            <name role="nrol:short">BATE Borisov</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -3906,7 +3906,7 @@
                     <team id="EFBO782719-TFBB174">
                         <team-metadata key="vendteam:TFBB174" alignment="away">
                             <name role="nrol:full">Athletic Club</name>
-                            <name part="nprt:common">Athletic Club</name>
+                            <name role="nrol:short">Athletic Club</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -3941,7 +3941,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7761">
                                 <name role="nrol:full">Arena Lviv</name>
-                                <name part="nprt:common">Arena Lviv</name>
+                                <name role="nrol:short">Arena Lviv</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -3955,7 +3955,7 @@
                     <team id="EFBO782720-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="home">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -3971,7 +3971,7 @@
                     <team id="EFBO782720-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="away">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4011,7 +4011,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB9764">
                                 <name role="nrol:full">Borisov Arena</name>
-                                <name part="nprt:common">Borisov Arena</name>
+                                <name role="nrol:short">Borisov Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4025,7 +4025,7 @@
                     <team id="EFBO782735-TFBB2155">
                         <team-metadata key="vendteam:TFBB2155" alignment="home">
                             <name role="nrol:full">BATE Borisov</name>
-                            <name part="nprt:common">BATE Borisov</name>
+                            <name role="nrol:short">BATE Borisov</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="7" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4035,7 +4035,7 @@
                     <team id="EFBO782735-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="away">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="7" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="6"/>
@@ -4096,7 +4096,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2710">
                                 <name role="nrol:full">Estadio do Dragão</name>
-                                <name part="nprt:common">Estadio do Dragão</name>
+                                <name role="nrol:short">Estadio do Dragão</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4110,7 +4110,7 @@
                     <team id="EFBO782736-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="home">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -4126,7 +4126,7 @@
                     <team id="EFBO782736-TFBB174">
                         <team-metadata key="vendteam:TFBB174" alignment="away">
                             <name role="nrol:full">Athletic Club</name>
-                            <name part="nprt:common">Athletic Club</name>
+                            <name role="nrol:short">Athletic Club</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4161,7 +4161,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB8973">
                                 <name role="nrol:full">San Mamés</name>
-                                <name part="nprt:common">San Mamés</name>
+                                <name role="nrol:short">San Mamés</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4175,7 +4175,7 @@
                     <team id="EFBO782759-TFBB174">
                         <team-metadata key="vendteam:TFBB174" alignment="home">
                             <name role="nrol:full">Athletic Club</name>
-                            <name part="nprt:common">Athletic Club</name>
+                            <name role="nrol:short">Athletic Club</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4185,7 +4185,7 @@
                     <team id="EFBO782759-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="away">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -4218,7 +4218,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7761">
                                 <name role="nrol:full">Arena Lviv</name>
-                                <name part="nprt:common">Arena Lviv</name>
+                                <name role="nrol:short">Arena Lviv</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4232,7 +4232,7 @@
                     <team id="EFBO782760-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="home">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="5" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -4251,7 +4251,7 @@
                     <team id="EFBO782760-TFBB2155">
                         <team-metadata key="vendteam:TFBB2155" alignment="away">
                             <name role="nrol:full">BATE Borisov</name>
-                            <name part="nprt:common">BATE Borisov</name>
+                            <name role="nrol:short">BATE Borisov</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="5" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4293,7 +4293,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB9764">
                                 <name role="nrol:full">Borisov Arena</name>
-                                <name part="nprt:common">Borisov Arena</name>
+                                <name role="nrol:short">Borisov Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4307,7 +4307,7 @@
                     <team id="EFBO782767-TFBB2155">
                         <team-metadata key="vendteam:TFBB2155" alignment="home">
                             <name role="nrol:full">BATE Borisov</name>
-                            <name part="nprt:common">BATE Borisov</name>
+                            <name role="nrol:short">BATE Borisov</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4317,7 +4317,7 @@
                     <team id="EFBO782767-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="away">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -4358,7 +4358,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7761">
                                 <name role="nrol:full">Arena Lviv</name>
-                                <name part="nprt:common">Arena Lviv</name>
+                                <name role="nrol:short">Arena Lviv</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4372,7 +4372,7 @@
                     <team id="EFBO782768-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="home">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4382,7 +4382,7 @@
                     <team id="EFBO782768-TFBB174">
                         <team-metadata key="vendteam:TFBB174" alignment="away">
                             <name role="nrol:full">Athletic Club</name>
-                            <name part="nprt:common">Athletic Club</name>
+                            <name role="nrol:short">Athletic Club</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -4407,7 +4407,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB8973">
                                 <name role="nrol:full">San Mamés</name>
-                                <name part="nprt:common">San Mamés</name>
+                                <name role="nrol:short">San Mamés</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4421,7 +4421,7 @@
                     <team id="EFBO782791-TFBB174">
                         <team-metadata key="vendteam:TFBB174" alignment="home">
                             <name role="nrol:full">Athletic Club</name>
-                            <name part="nprt:common">Athletic Club</name>
+                            <name role="nrol:short">Athletic Club</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -4437,7 +4437,7 @@
                     <team id="EFBO782791-TFBB2155">
                         <team-metadata key="vendteam:TFBB2155" alignment="away">
                             <name role="nrol:full">BATE Borisov</name>
-                            <name part="nprt:common">BATE Borisov</name>
+                            <name role="nrol:short">BATE Borisov</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4464,7 +4464,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2710">
                                 <name role="nrol:full">Estadio do Dragão</name>
-                                <name part="nprt:common">Estadio do Dragão</name>
+                                <name role="nrol:short">Estadio do Dragão</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4478,7 +4478,7 @@
                     <team id="EFBO782792-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="home">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4491,7 +4491,7 @@
                     <team id="EFBO782792-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="away">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4519,7 +4519,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R7" number="7" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782709" event-status="speventstatus:post-event"
@@ -4528,7 +4528,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB35">
                                 <name role="nrol:full">Stamford Bridge</name>
-                                <name part="nprt:common">Stamford Bridge</name>
+                                <name role="nrol:short">Stamford Bridge</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4542,7 +4542,7 @@
                     <team id="EFBO782709-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="home">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -4555,7 +4555,7 @@
                     <team id="EFBO782709-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="away">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4585,7 +4585,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3328">
                                 <name role="nrol:full">Ljudski vrt</name>
-                                <name part="nprt:common">Ljudski vrt</name>
+                                <name role="nrol:short">Ljudski vrt</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4599,7 +4599,7 @@
                     <team id="EFBO782710-TFBB3033">
                         <team-metadata key="vendteam:TFBB3033" alignment="home">
                             <name role="nrol:full">NK Maribor</name>
-                            <name part="nprt:common">NK Maribor</name>
+                            <name role="nrol:short">NK Maribor</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4612,7 +4612,7 @@
                     <team id="EFBO782710-TFBB255">
                         <team-metadata key="vendteam:TFBB255" alignment="away">
                             <name role="nrol:full">Sporting Lisbon</name>
-                            <name part="nprt:common">Sporting Lisbon</name>
+                            <name role="nrol:short">Sporting Lisbon</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4642,7 +4642,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2095">
                                 <name role="nrol:full">VELTINS-Arena</name>
-                                <name part="nprt:common">VELTINS-Arena</name>
+                                <name role="nrol:short">VELTINS-Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4656,7 +4656,7 @@
                     <team id="EFBO782717-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="home">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4669,7 +4669,7 @@
                     <team id="EFBO782717-TFBB3033">
                         <team-metadata key="vendteam:TFBB3033" alignment="away">
                             <name role="nrol:full">NK Maribor</name>
-                            <name part="nprt:common">NK Maribor</name>
+                            <name role="nrol:short">NK Maribor</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -4699,7 +4699,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2116">
                                 <name role="nrol:full">Estadio José Alvalade</name>
-                                <name part="nprt:common">Estadio José Alvalade</name>
+                                <name role="nrol:short">Estadio José Alvalade</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4713,7 +4713,7 @@
                     <team id="EFBO782718-TFBB255">
                         <team-metadata key="vendteam:TFBB255" alignment="home">
                             <name role="nrol:full">Sporting Lisbon</name>
-                            <name part="nprt:common">Sporting Lisbon</name>
+                            <name role="nrol:short">Sporting Lisbon</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4723,7 +4723,7 @@
                     <team id="EFBO782718-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="away">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -4748,7 +4748,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB35">
                                 <name role="nrol:full">Stamford Bridge</name>
-                                <name part="nprt:common">Stamford Bridge</name>
+                                <name role="nrol:short">Stamford Bridge</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4762,7 +4762,7 @@
                     <team id="EFBO782733-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="home">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="6" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -4787,7 +4787,7 @@
                     <team id="EFBO782733-TFBB3033">
                         <team-metadata key="vendteam:TFBB3033" alignment="away">
                             <name role="nrol:full">NK Maribor</name>
-                            <name part="nprt:common">NK Maribor</name>
+                            <name role="nrol:short">NK Maribor</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="6" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -4834,7 +4834,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2095">
                                 <name role="nrol:full">VELTINS-Arena</name>
-                                <name part="nprt:common">VELTINS-Arena</name>
+                                <name role="nrol:short">VELTINS-Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4848,7 +4848,7 @@
                     <team id="EFBO782734-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="home">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="3" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -4870,7 +4870,7 @@
                     <team id="EFBO782734-TFBB255">
                         <team-metadata key="vendteam:TFBB255" alignment="away">
                             <name role="nrol:full">Sporting Lisbon</name>
-                            <name part="nprt:common">Sporting Lisbon</name>
+                            <name role="nrol:short">Sporting Lisbon</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -4928,7 +4928,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3328">
                                 <name role="nrol:full">Ljudski vrt</name>
-                                <name part="nprt:common">Ljudski vrt</name>
+                                <name role="nrol:short">Ljudski vrt</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4942,7 +4942,7 @@
                     <team id="EFBO782757-TFBB3033">
                         <team-metadata key="vendteam:TFBB3033" alignment="home">
                             <name role="nrol:full">NK Maribor</name>
-                            <name part="nprt:common">NK Maribor</name>
+                            <name role="nrol:short">NK Maribor</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4955,7 +4955,7 @@
                     <team id="EFBO782757-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="away">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -4985,7 +4985,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2116">
                                 <name role="nrol:full">Estadio José Alvalade</name>
-                                <name part="nprt:common">Estadio José Alvalade</name>
+                                <name role="nrol:short">Estadio José Alvalade</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -4999,7 +4999,7 @@
                     <team id="EFBO782758-TFBB255">
                         <team-metadata key="vendteam:TFBB255" alignment="home">
                             <name role="nrol:full">Sporting Lisbon</name>
-                            <name part="nprt:common">Sporting Lisbon</name>
+                            <name role="nrol:short">Sporting Lisbon</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -5021,7 +5021,7 @@
                     <team id="EFBO782758-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="away">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -5071,7 +5071,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2095">
                                 <name role="nrol:full">VELTINS-Arena</name>
-                                <name part="nprt:common">VELTINS-Arena</name>
+                                <name role="nrol:short">VELTINS-Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5085,7 +5085,7 @@
                     <team id="EFBO782765-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="home">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="5" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5095,7 +5095,7 @@
                     <team id="EFBO782765-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="away">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="5" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="3"/>
@@ -5152,7 +5152,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2116">
                                 <name role="nrol:full">Estadio José Alvalade</name>
-                                <name part="nprt:common">Estadio José Alvalade</name>
+                                <name role="nrol:short">Estadio José Alvalade</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5166,7 +5166,7 @@
                     <team id="EFBO782766-TFBB255">
                         <team-metadata key="vendteam:TFBB255" alignment="home">
                             <name role="nrol:full">Sporting Lisbon</name>
-                            <name part="nprt:common">Sporting Lisbon</name>
+                            <name role="nrol:short">Sporting Lisbon</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -5185,7 +5185,7 @@
                     <team id="EFBO782766-TFBB3033">
                         <team-metadata key="vendteam:TFBB3033" alignment="away">
                             <name role="nrol:full">NK Maribor</name>
-                            <name part="nprt:common">NK Maribor</name>
+                            <name role="nrol:short">NK Maribor</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -5226,7 +5226,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB35">
                                 <name role="nrol:full">Stamford Bridge</name>
-                                <name part="nprt:common">Stamford Bridge</name>
+                                <name role="nrol:short">Stamford Bridge</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5240,7 +5240,7 @@
                     <team id="EFBO782789-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="home">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -5259,7 +5259,7 @@
                     <team id="EFBO782789-TFBB255">
                         <team-metadata key="vendteam:TFBB255" alignment="away">
                             <name role="nrol:full">Sporting Lisbon</name>
-                            <name part="nprt:common">Sporting Lisbon</name>
+                            <name role="nrol:short">Sporting Lisbon</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5299,7 +5299,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3328">
                                 <name role="nrol:full">Ljudski vrt</name>
-                                <name part="nprt:common">Ljudski vrt</name>
+                                <name role="nrol:short">Ljudski vrt</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5313,7 +5313,7 @@
                     <team id="EFBO782790-TFBB3033">
                         <team-metadata key="vendteam:TFBB3033" alignment="home">
                             <name role="nrol:full">NK Maribor</name>
-                            <name part="nprt:common">NK Maribor</name>
+                            <name role="nrol:short">NK Maribor</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5323,7 +5323,7 @@
                     <team id="EFBO782790-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="away">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -5346,7 +5346,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S1R5" number="5" format-type="sptournamentform:single-group"
                     maximum-subparts="12" minimum-subparts="12">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO782705" event-status="speventstatus:post-event"
@@ -5355,7 +5355,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2775">
                                 <name role="nrol:full">Allianz Arena</name>
-                                <name part="nprt:common">Allianz Arena</name>
+                                <name role="nrol:short">Allianz Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5369,7 +5369,7 @@
                     <team id="EFBO782705-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="home">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -5382,7 +5382,7 @@
                     <team id="EFBO782705-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="away">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5404,7 +5404,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1336">
                                 <name role="nrol:full">Olimpico</name>
-                                <name part="nprt:common">Olimpico</name>
+                                <name role="nrol:short">Olimpico</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5418,7 +5418,7 @@
                     <team id="EFBO782706-TFBB121">
                         <team-metadata key="vendteam:TFBB121" alignment="home">
                             <name role="nrol:full">Roma</name>
-                            <name part="nprt:common">Roma</name>
+                            <name role="nrol:short">Roma</name>
                         </team-metadata>
                         <team-stats score="5" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="4"/>
@@ -5440,7 +5440,7 @@
                     <team id="EFBO782706-TFBB1340">
                         <team-metadata key="vendteam:TFBB1340" alignment="away">
                             <name role="nrol:full">CSKA Moscow</name>
-                            <name part="nprt:common">CSKA Moscow</name>
+                            <name role="nrol:short">CSKA Moscow</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="5" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5490,7 +5490,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB5047">
                                 <name role="nrol:full">Arena Khimki</name>
-                                <name part="nprt:common">Arena Khimki</name>
+                                <name role="nrol:short">Arena Khimki</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5504,7 +5504,7 @@
                     <team id="EFBO782713-TFBB1340">
                         <team-metadata key="vendteam:TFBB1340" alignment="home">
                             <name role="nrol:full">CSKA Moscow</name>
-                            <name part="nprt:common">CSKA Moscow</name>
+                            <name role="nrol:short">CSKA Moscow</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5514,7 +5514,7 @@
                     <team id="EFBO782713-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="away">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -5539,7 +5539,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2691">
                                 <name role="nrol:full">Etihad Stadium</name>
-                                <name part="nprt:common">Etihad Stadium</name>
+                                <name role="nrol:short">Etihad Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5553,7 +5553,7 @@
                     <team id="EFBO782714-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="home">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -5566,7 +5566,7 @@
                     <team id="EFBO782714-TFBB121">
                         <team-metadata key="vendteam:TFBB121" alignment="away">
                             <name role="nrol:full">Roma</name>
-                            <name part="nprt:common">Roma</name>
+                            <name role="nrol:short">Roma</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -5596,7 +5596,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB5047">
                                 <name role="nrol:full">Arena Khimki</name>
-                                <name part="nprt:common">Arena Khimki</name>
+                                <name role="nrol:short">Arena Khimki</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5610,7 +5610,7 @@
                     <team id="EFBO782729-TFBB1340">
                         <team-metadata key="vendteam:TFBB1340" alignment="home">
                             <name role="nrol:full">CSKA Moscow</name>
-                            <name part="nprt:common">CSKA Moscow</name>
+                            <name role="nrol:short">CSKA Moscow</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -5626,7 +5626,7 @@
                     <team id="EFBO782729-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="away">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="2"/>
@@ -5669,7 +5669,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1336">
                                 <name role="nrol:full">Olimpico</name>
-                                <name part="nprt:common">Olimpico</name>
+                                <name role="nrol:short">Olimpico</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5683,7 +5683,7 @@
                     <team id="EFBO782730-TFBB121">
                         <team-metadata key="vendteam:TFBB121" alignment="home">
                             <name role="nrol:full">Roma</name>
-                            <name part="nprt:common">Roma</name>
+                            <name role="nrol:short">Roma</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="7" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5696,7 +5696,7 @@
                     <team id="EFBO782730-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="away">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="7" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="5"/>
@@ -5771,7 +5771,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2775">
                                 <name role="nrol:full">Allianz Arena</name>
-                                <name part="nprt:common">Allianz Arena</name>
+                                <name role="nrol:short">Allianz Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5785,7 +5785,7 @@
                     <team id="EFBO782753-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="home">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -5801,7 +5801,7 @@
                     <team id="EFBO782753-TFBB121">
                         <team-metadata key="vendteam:TFBB121" alignment="away">
                             <name role="nrol:full">Roma</name>
-                            <name part="nprt:common">Roma</name>
+                            <name role="nrol:short">Roma</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -5828,7 +5828,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2691">
                                 <name role="nrol:full">Etihad Stadium</name>
-                                <name part="nprt:common">Etihad Stadium</name>
+                                <name role="nrol:short">Etihad Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5842,7 +5842,7 @@
                     <team id="EFBO782754-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="home">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -5855,7 +5855,7 @@
                     <team id="EFBO782754-TFBB1340">
                         <team-metadata key="vendteam:TFBB1340" alignment="away">
                             <name role="nrol:full">CSKA Moscow</name>
-                            <name part="nprt:common">CSKA Moscow</name>
+                            <name role="nrol:short">CSKA Moscow</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -5890,7 +5890,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB5047">
                                 <name role="nrol:full">Arena Khimki</name>
-                                <name part="nprt:common">Arena Khimki</name>
+                                <name role="nrol:short">Arena Khimki</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5904,7 +5904,7 @@
                     <team id="EFBO782761-TFBB1340">
                         <team-metadata key="vendteam:TFBB1340" alignment="home">
                             <name role="nrol:full">CSKA Moscow</name>
-                            <name part="nprt:common">CSKA Moscow</name>
+                            <name role="nrol:short">CSKA Moscow</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -5917,7 +5917,7 @@
                     <team id="EFBO782761-TFBB121">
                         <team-metadata key="vendteam:TFBB121" alignment="away">
                             <name role="nrol:full">Roma</name>
-                            <name part="nprt:common">Roma</name>
+                            <name role="nrol:short">Roma</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -5947,7 +5947,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2691">
                                 <name role="nrol:full">Etihad Stadium</name>
-                                <name part="nprt:common">Etihad Stadium</name>
+                                <name role="nrol:short">Etihad Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -5961,7 +5961,7 @@
                     <team id="EFBO782762-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="home">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -5974,7 +5974,7 @@
                     <team id="EFBO782762-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="away">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="2"/>
@@ -6022,7 +6022,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2775">
                                 <name role="nrol:full">Allianz Arena</name>
-                                <name part="nprt:common">Allianz Arena</name>
+                                <name role="nrol:short">Allianz Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6036,7 +6036,7 @@
                     <team id="EFBO782785-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="home">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -6055,7 +6055,7 @@
                     <team id="EFBO782785-TFBB1340">
                         <team-metadata key="vendteam:TFBB1340" alignment="away">
                             <name role="nrol:full">CSKA Moscow</name>
-                            <name part="nprt:common">CSKA Moscow</name>
+                            <name role="nrol:short">CSKA Moscow</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6087,7 +6087,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1336">
                                 <name role="nrol:full">Olimpico</name>
-                                <name part="nprt:common">Olimpico</name>
+                                <name role="nrol:short">Olimpico</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6101,7 +6101,7 @@
                     <team id="EFBO782786-TFBB121">
                         <team-metadata key="vendteam:TFBB121" alignment="home">
                             <name role="nrol:full">Roma</name>
-                            <name part="nprt:common">Roma</name>
+                            <name role="nrol:short">Roma</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6111,7 +6111,7 @@
                     <team id="EFBO782786-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="away">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -6143,13 +6143,13 @@
             <tournament-part-metadata key="vendkey:CFBB52014S2" type="sptournamentphase:elimination" number="2"
                 maximum-subparts="4" minimum-subparts="4">
                 <name role="nrol:full">Champions League</name>
-                <name part="nprt:common">Champions League</name>
+                <name role="nrol:short">Champions League</name>
             </tournament-part-metadata>
             <tournament-part>
                 <tournament-part-metadata key="vendkey:CFBB52014S2R1" number="1"
                     format-type="sptournamentform:home-and-home" maximum-subparts="16" minimum-subparts="16">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO788097" event-status="speventstatus:post-event"
@@ -6163,7 +6163,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1311">
                                 <name role="nrol:full">Parc des Princes</name>
-                                <name part="nprt:common">Parc des Princes</name>
+                                <name role="nrol:short">Parc des Princes</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6177,7 +6177,7 @@
                     <team id="EFBO788097-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="home">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -6190,7 +6190,7 @@
                     <team id="EFBO788097-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="away">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -6225,7 +6225,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7761">
                                 <name role="nrol:full">Arena Lviv</name>
-                                <name part="nprt:common">Arena Lviv</name>
+                                <name role="nrol:short">Arena Lviv</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6239,7 +6239,7 @@
                     <team id="EFBO788103-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="home">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -6249,7 +6249,7 @@
                     <team id="EFBO788103-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="away">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -6269,7 +6269,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2208">
                                 <name role="nrol:full">St Jakob-Park</name>
-                                <name part="nprt:common">St Jakob-Park</name>
+                                <name role="nrol:short">St Jakob-Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6283,7 +6283,7 @@
                     <team id="EFBO788105-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="home">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -6296,7 +6296,7 @@
                     <team id="EFBO788105-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="away">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -6331,7 +6331,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2095">
                                 <name role="nrol:full">VELTINS-Arena</name>
-                                <name part="nprt:common">VELTINS-Arena</name>
+                                <name role="nrol:short">VELTINS-Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6345,7 +6345,7 @@
                     <team id="EFBO788102-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="home">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6355,7 +6355,7 @@
                     <team id="EFBO788102-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="away">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -6393,7 +6393,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7598">
                                 <name role="nrol:full">Juventus Stadium</name>
-                                <name part="nprt:common">Juventus Stadium</name>
+                                <name role="nrol:short">Juventus Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6407,7 +6407,7 @@
                     <team id="EFBO788101-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -6423,7 +6423,7 @@
                     <team id="EFBO788101-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="away">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -6463,7 +6463,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2691">
                                 <name role="nrol:full">Etihad Stadium</name>
-                                <name part="nprt:common">Etihad Stadium</name>
+                                <name role="nrol:short">Etihad Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6477,7 +6477,7 @@
                     <team id="EFBO788099-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="home">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6490,7 +6490,7 @@
                     <team id="EFBO788099-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -6530,7 +6530,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB3250">
                                 <name role="nrol:full">Emirates Stadium</name>
-                                <name part="nprt:common">Emirates Stadium</name>
+                                <name role="nrol:short">Emirates Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6544,7 +6544,7 @@
                     <team id="EFBO788104-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="home">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6557,7 +6557,7 @@
                     <team id="EFBO788104-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="away">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -6608,7 +6608,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1368">
                                 <name role="nrol:full">BayArena</name>
-                                <name part="nprt:common">BayArena</name>
+                                <name role="nrol:short">BayArena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6622,7 +6622,7 @@
                     <team id="EFBO788100-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="home">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -6635,7 +6635,7 @@
                     <team id="EFBO788100-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="away">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6664,7 +6664,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2710">
                                 <name role="nrol:full">Estadio do Dragão</name>
-                                <name part="nprt:common">Estadio do Dragão</name>
+                                <name role="nrol:short">Estadio do Dragão</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6678,7 +6678,7 @@
                     <team id="EFBO788113-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="home">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -6703,7 +6703,7 @@
                     <team id="EFBO788113-TFBB481">
                         <team-metadata key="vendteam:TFBB481" alignment="away">
                             <name role="nrol:full">FC Basel</name>
-                            <name part="nprt:common">FC Basel</name>
+                            <name role="nrol:short">FC Basel</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -6750,7 +6750,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1360">
                                 <name role="nrol:full">Santiago Bernabéu</name>
-                                <name part="nprt:common">Santiago Bernabéu</name>
+                                <name role="nrol:short">Santiago Bernabéu</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6764,7 +6764,7 @@
                     <team id="EFBO788110-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="home">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="4" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="2"/>
@@ -6783,7 +6783,7 @@
                     <team id="EFBO788110-TFBB167">
                         <team-metadata key="vendteam:TFBB167" alignment="away">
                             <name role="nrol:full">FC Schalke 04</name>
-                            <name part="nprt:common">FC Schalke 04</name>
+                            <name role="nrol:short">FC Schalke 04</name>
                         </team-metadata>
                         <team-stats score="4" score-opposing="3" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -6852,7 +6852,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB35">
                                 <name role="nrol:full">Stamford Bridge</name>
-                                <name part="nprt:common">Stamford Bridge</name>
+                                <name role="nrol:short">Stamford Bridge</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6866,7 +6866,7 @@
                     <team id="EFBO788106-TFBB8">
                         <team-metadata key="vendteam:TFBB8" alignment="home">
                             <name role="nrol:full">Chelsea</name>
-                            <name part="nprt:common">Chelsea</name>
+                            <name role="nrol:short">Chelsea</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -6887,7 +6887,7 @@
                     <team id="EFBO788106-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="away">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="2" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -6943,7 +6943,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2775">
                                 <name role="nrol:full">Allianz Arena</name>
-                                <name part="nprt:common">Allianz Arena</name>
+                                <name role="nrol:short">Allianz Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -6957,7 +6957,7 @@
                     <team id="EFBO788111-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="home">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="7" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -6988,7 +6988,7 @@
                     <team id="EFBO788111-TFBB455">
                         <team-metadata key="vendteam:TFBB455" alignment="away">
                             <name role="nrol:full">Shakhtar Donetsk</name>
-                            <name part="nprt:common">Shakhtar Donetsk</name>
+                            <name role="nrol:short">Shakhtar Donetsk</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="7" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7051,7 +7051,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2599">
                                 <name role="nrol:full">Vicente Calderón</name>
-                                <name part="nprt:common">Vicente Calderón</name>
+                                <name role="nrol:short">Vicente Calderón</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7065,7 +7065,7 @@
                     <team id="EFBO788108-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="home">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -7091,7 +7091,7 @@
                     <team id="EFBO788108-TFBB164">
                         <team-metadata key="vendteam:TFBB164" alignment="away">
                             <name role="nrol:full">Bayer 04 Leverkusen</name>
-                            <name part="nprt:common">Bayer 04 Leverkusen</name>
+                            <name role="nrol:short">Bayer 04 Leverkusen</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7158,7 +7158,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1313">
                                 <name role="nrol:full">Stade Louis II</name>
-                                <name part="nprt:common">Stade Louis II</name>
+                                <name role="nrol:short">Stade Louis II</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7172,7 +7172,7 @@
                     <team id="EFBO788112-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="home">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7185,7 +7185,7 @@
                     <team id="EFBO788112-TFBB3">
                         <team-metadata key="vendteam:TFBB3" alignment="away">
                             <name role="nrol:full">Arsenal</name>
-                            <name part="nprt:common">Arsenal</name>
+                            <name role="nrol:short">Arsenal</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -7228,7 +7228,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1349">
                                 <name role="nrol:full">Camp Nou</name>
-                                <name part="nprt:common">Camp Nou</name>
+                                <name role="nrol:short">Camp Nou</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7242,7 +7242,7 @@
                     <team id="EFBO788107-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="home">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -7258,7 +7258,7 @@
                     <team id="EFBO788107-TFBB43">
                         <team-metadata key="vendteam:TFBB43" alignment="away">
                             <name role="nrol:full">Manchester City</name>
-                            <name part="nprt:common">Manchester City</name>
+                            <name role="nrol:short">Manchester City</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7290,7 +7290,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1369">
                                 <name role="nrol:full">Signal Iduna Park</name>
-                                <name part="nprt:common">Signal Iduna Park</name>
+                                <name role="nrol:short">Signal Iduna Park</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7304,7 +7304,7 @@
                     <team id="EFBO788109-TFBB157">
                         <team-metadata key="vendteam:TFBB157" alignment="home">
                             <name role="nrol:full">Borussia Dortmund</name>
-                            <name part="nprt:common">Borussia Dortmund</name>
+                            <name role="nrol:short">Borussia Dortmund</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7317,7 +7317,7 @@
                     <team id="EFBO788109-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="away">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -7356,7 +7356,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S2R2" number="2"
                     format-type="sptournamentform:home-and-home" maximum-subparts="8" minimum-subparts="8">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO799715" event-status="speventstatus:post-event"
@@ -7370,7 +7370,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2599">
                                 <name role="nrol:full">Vicente Calderón</name>
-                                <name part="nprt:common">Vicente Calderón</name>
+                                <name role="nrol:short">Vicente Calderón</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7384,7 +7384,7 @@
                     <team id="EFBO799715-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="home">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -7394,7 +7394,7 @@
                     <team id="EFBO799715-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="away">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -7414,7 +7414,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7598">
                                 <name role="nrol:full">Juventus Stadium</name>
-                                <name part="nprt:common">Juventus Stadium</name>
+                                <name role="nrol:short">Juventus Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7428,7 +7428,7 @@
                     <team id="EFBO799713-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -7441,7 +7441,7 @@
                     <team id="EFBO799713-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="away">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7468,7 +7468,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2710">
                                 <name role="nrol:full">Estadio do Dragão</name>
-                                <name part="nprt:common">Estadio do Dragão</name>
+                                <name role="nrol:short">Estadio do Dragão</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7482,7 +7482,7 @@
                     <team id="EFBO799720-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="home">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -7498,7 +7498,7 @@
                     <team id="EFBO799720-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="away">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -7543,7 +7543,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1311">
                                 <name role="nrol:full">Parc des Princes</name>
-                                <name part="nprt:common">Parc des Princes</name>
+                                <name role="nrol:short">Parc des Princes</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7557,7 +7557,7 @@
                     <team id="EFBO799717-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="home">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7570,7 +7570,7 @@
                     <team id="EFBO799717-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -7620,7 +7620,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1349">
                                 <name role="nrol:full">Camp Nou</name>
-                                <name part="nprt:common">Camp Nou</name>
+                                <name role="nrol:short">Camp Nou</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7634,7 +7634,7 @@
                     <team id="EFBO799718-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="home">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="2"/>
@@ -7650,7 +7650,7 @@
                     <team id="EFBO799718-TFBB149">
                         <team-metadata key="vendteam:TFBB149" alignment="away">
                             <name role="nrol:full">Paris Saint-Germain</name>
-                            <name part="nprt:common">Paris Saint-Germain</name>
+                            <name role="nrol:short">Paris Saint-Germain</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7688,7 +7688,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2775">
                                 <name role="nrol:full">Allianz Arena</name>
-                                <name part="nprt:common">Allianz Arena</name>
+                                <name role="nrol:short">Allianz Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7702,7 +7702,7 @@
                     <team id="EFBO799723-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="home">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="6" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="5"/>
@@ -7730,7 +7730,7 @@
                     <team id="EFBO799723-TFBB201">
                         <team-metadata key="vendteam:TFBB201" alignment="away">
                             <name role="nrol:full">FC Porto</name>
-                            <name part="nprt:common">FC Porto</name>
+                            <name role="nrol:short">FC Porto</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="6" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7795,7 +7795,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1313">
                                 <name role="nrol:full">Stade Louis II</name>
-                                <name part="nprt:common">Stade Louis II</name>
+                                <name role="nrol:short">Stade Louis II</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7809,7 +7809,7 @@
                     <team id="EFBO799714-TFBB146">
                         <team-metadata key="vendteam:TFBB146" alignment="home">
                             <name role="nrol:full">Monaco</name>
-                            <name part="nprt:common">Monaco</name>
+                            <name role="nrol:short">Monaco</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -7822,7 +7822,7 @@
                     <team id="EFBO799714-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="away">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="0" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -7847,7 +7847,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1360">
                                 <name role="nrol:full">Santiago Bernabéu</name>
-                                <name part="nprt:common">Santiago Bernabéu</name>
+                                <name role="nrol:short">Santiago Bernabéu</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7861,7 +7861,7 @@
                     <team id="EFBO799716-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="home">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -7877,7 +7877,7 @@
                     <team id="EFBO799716-TFBB175">
                         <team-metadata key="vendteam:TFBB175" alignment="away">
                             <name role="nrol:full">Atlético de Madrid</name>
-                            <name part="nprt:common">Atlético de Madrid</name>
+                            <name role="nrol:short">Atlético de Madrid</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="1" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -7900,7 +7900,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S2R3" number="3"
                     format-type="sptournamentform:home-and-home" maximum-subparts="4" minimum-subparts="4">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO800858" event-status="speventstatus:post-event"
@@ -7914,7 +7914,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB7598">
                                 <name role="nrol:full">Juventus Stadium</name>
-                                <name part="nprt:common">Juventus Stadium</name>
+                                <name role="nrol:short">Juventus Stadium</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7928,7 +7928,7 @@
                     <team id="EFBO800858-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="1" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -7944,7 +7944,7 @@
                     <team id="EFBO800858-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="away">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="2" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="1"/>
@@ -7984,7 +7984,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1349">
                                 <name role="nrol:full">Camp Nou</name>
-                                <name part="nprt:common">Camp Nou</name>
+                                <name role="nrol:short">Camp Nou</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -7998,7 +7998,7 @@
                     <team id="EFBO800857-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="home">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="0" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="0"/>
@@ -8014,7 +8014,7 @@
                     <team id="EFBO800857-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="away">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="0" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="0"/>
@@ -8053,7 +8053,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB2775">
                                 <name role="nrol:full">Allianz Arena</name>
-                                <name part="nprt:common">Allianz Arena</name>
+                                <name role="nrol:short">Allianz Arena</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -8067,7 +8067,7 @@
                     <team id="EFBO800859-TFBB156">
                         <team-metadata key="vendteam:TFBB156" alignment="home">
                             <name role="nrol:full">FC Bayern München</name>
-                            <name part="nprt:common">FC Bayern München</name>
+                            <name role="nrol:short">FC Bayern München</name>
                         </team-metadata>
                         <team-stats score="3" score-opposing="2" event-outcome="speventoutcome:win">
                             <sub-score period-value="1" score="1"/>
@@ -8089,7 +8089,7 @@
                     <team id="EFBO800859-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                         <team-stats score="2" score-opposing="3" event-outcome="speventoutcome:loss">
                             <sub-score period-value="1" score="2"/>
@@ -8144,7 +8144,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1360">
                                 <name role="nrol:full">Santiago Bernabéu</name>
-                                <name part="nprt:common">Santiago Bernabéu</name>
+                                <name role="nrol:short">Santiago Bernabéu</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -8158,7 +8158,7 @@
                     <team id="EFBO800860-TFBB186">
                         <team-metadata key="vendteam:TFBB186" alignment="home">
                             <name role="nrol:full">Real Madrid</name>
-                            <name part="nprt:common">Real Madrid</name>
+                            <name role="nrol:short">Real Madrid</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="1"/>
@@ -8174,7 +8174,7 @@
                     <team id="EFBO800860-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="away">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                         <team-stats score="1" score-opposing="1" event-outcome="speventoutcome:tie">
                             <sub-score period-value="1" score="0"/>
@@ -8205,7 +8205,7 @@
                 <tournament-part-metadata key="vendkey:CFBB52014S2R4" number="4"
                     format-type="sptournamentform:single-elimination" maximum-subparts="1" minimum-subparts="1">
                     <name role="nrol:full">Champions League</name>
-                    <name part="nprt:common">Champions League</name>
+                    <name role="nrol:short">Champions League</name>
                 </tournament-part-metadata>
                 <sports-event>
                     <event-metadata key="vendevent:EFBO800865" event-status="speventstatus:pre-event"
@@ -8214,7 +8214,7 @@
                         <site>
                             <site-metadata key="vendsite:VFBB1375">
                                 <name role="nrol:full">Olympiastadion</name>
-                                <name part="nprt:common">Olympiastadion</name>
+                                <name role="nrol:short">Olympiastadion</name>
                                 <home-location>
                                     <POIDetails>
                                         <address/>
@@ -8228,13 +8228,13 @@
                     <team id="EFBO800865-TFBB128">
                         <team-metadata key="vendteam:TFBB128" alignment="home">
                             <name role="nrol:full">Juventus</name>
-                            <name part="nprt:common">Juventus</name>
+                            <name role="nrol:short">Juventus</name>
                         </team-metadata>
                     </team>
                     <team id="EFBO800865-TFBB178">
                         <team-metadata key="vendteam:TFBB178" alignment="away">
                             <name role="nrol:full">Barcelona</name>
-                            <name part="nprt:common">Barcelona</name>
+                            <name role="nrol:short">Barcelona</name>
                         </team-metadata>
                     </team>
                 </sports-event>

--- a/3.0/examples/tournament-cl-g2.xml
+++ b/3.0/examples/tournament-cl-g2.xml
@@ -68,19 +68,19 @@
                     <tournament-metadata temporal-unit-type="spct:tournament"
                         temporal-unit-value="vendor:2014" key="vendperson:CFBB5">
                         <name role="nrol:full">Champions League</name>
-                        <name part="nprt:common">Champions League</name>
+                        <name role="nrol:short">Champions League</name>
                     </tournament-metadata>
                     <tournament-part>
                         <tournament-part-metadata key="vendkey:CFBB52014S1" type="sptournamentphase:group" number="1"
                             maximum-subparts="8" minimum-subparts="8">
                             <name role="nrol:full">Champions League Group Phase</name>
-                            <name part="nprt:common">Groups</name>
+                            <name role="nrol:short">Groups</name>
                         </tournament-part-metadata>
                         <tournament-part>
                             <tournament-part-metadata key="vendkey:CFBB52014S1R3" number="3"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League 2015 Group A</name>
-                                <name part="nprt:common">Group A</name>
+                                <name role="nrol:short">Group A</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782701"
@@ -90,7 +90,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2713">
                                             <name role="nrol:full">Estádio da Luz</name>
-                                            <name part="nprt:common">Estádio da Luz</name>
+                                            <name role="nrol:short">Estádio da Luz</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -104,7 +104,7 @@
                                 <team id="EFBO782701-TFBB251">
                                     <team-metadata key="vendteam:TFBB251" alignment="home">
                                         <name role="nrol:full">Benfica</name>
-                                        <name part="nprt:common">Benfica</name>
+                                        <name role="nrol:short">Benfica</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -115,7 +115,7 @@
                                 <team id="EFBO782701-TFBB1341">
                                     <team-metadata key="vendteam:TFBB1341" alignment="away">
                                         <name role="nrol:full">Zenit St Petersburg</name>
-                                        <name part="nprt:common">Zenit St Petersburg</name>
+                                        <name role="nrol:short">Zenit St Petersburg</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -154,7 +154,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1313">
                                             <name role="nrol:full">Stade Louis II</name>
-                                            <name part="nprt:common">Stade Louis II</name>
+                                            <name role="nrol:short">Stade Louis II</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -168,7 +168,7 @@
                                 <team id="EFBO782702-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="home">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -182,7 +182,7 @@
                                 <team id="EFBO782702-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="away">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -208,7 +208,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1368">
                                             <name role="nrol:full">BayArena</name>
-                                            <name part="nprt:common">BayArena</name>
+                                            <name role="nrol:short">BayArena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -222,7 +222,7 @@
                                 <team id="EFBO782725-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="home">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -242,7 +242,7 @@
                                 <team id="EFBO782725-TFBB251">
                                     <team-metadata key="vendteam:TFBB251" alignment="away">
                                         <name role="nrol:full">Benfica</name>
-                                        <name part="nprt:common">Benfica</name>
+                                        <name role="nrol:short">Benfica</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -292,7 +292,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2493">
                                             <name role="nrol:full">Petrovski Stadium</name>
-                                            <name part="nprt:common">Petrovski Stadium</name>
+                                            <name role="nrol:short">Petrovski Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -306,7 +306,7 @@
                                 <team id="EFBO782726-TFBB1341">
                                     <team-metadata key="vendteam:TFBB1341" alignment="home">
                                         <name role="nrol:full">Zenit St Petersburg</name>
-                                        <name part="nprt:common">Zenit St Petersburg</name>
+                                        <name role="nrol:short">Zenit St Petersburg</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -317,7 +317,7 @@
                                 <team id="EFBO782726-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="away">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -334,7 +334,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1368">
                                             <name role="nrol:full">BayArena</name>
-                                            <name part="nprt:common">BayArena</name>
+                                            <name role="nrol:short">BayArena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -348,7 +348,7 @@
                                 <team id="EFBO782741-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="home">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -365,7 +365,7 @@
                                 <team id="EFBO782741-TFBB1341">
                                     <team-metadata key="vendteam:TFBB1341" alignment="away">
                                         <name role="nrol:full">Zenit St Petersburg</name>
-                                        <name part="nprt:common">Zenit St Petersburg</name>
+                                        <name role="nrol:short">Zenit St Petersburg</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -398,7 +398,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1313">
                                             <name role="nrol:full">Stade Louis II</name>
-                                            <name part="nprt:common">Stade Louis II</name>
+                                            <name role="nrol:short">Stade Louis II</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -412,7 +412,7 @@
                                 <team id="EFBO782742-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="home">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -423,7 +423,7 @@
                                 <team id="EFBO782742-TFBB251">
                                     <team-metadata key="vendteam:TFBB251" alignment="away">
                                         <name role="nrol:full">Benfica</name>
-                                        <name part="nprt:common">Benfica</name>
+                                        <name role="nrol:short">Benfica</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -440,7 +440,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2713">
                                             <name role="nrol:full">Estádio da Luz</name>
-                                            <name part="nprt:common">Estádio da Luz</name>
+                                            <name role="nrol:short">Estádio da Luz</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -454,7 +454,7 @@
                                 <team id="EFBO782749-TFBB251">
                                     <team-metadata key="vendteam:TFBB251" alignment="home">
                                         <name role="nrol:full">Benfica</name>
-                                        <name part="nprt:common">Benfica</name>
+                                        <name role="nrol:short">Benfica</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -468,7 +468,7 @@
                                 <team id="EFBO782749-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="away">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -494,7 +494,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2493">
                                             <name role="nrol:full">Petrovski Stadium</name>
-                                            <name part="nprt:common">Petrovski Stadium</name>
+                                            <name role="nrol:short">Petrovski Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -508,7 +508,7 @@
                                 <team id="EFBO782750-TFBB1341">
                                     <team-metadata key="vendteam:TFBB1341" alignment="home">
                                         <name role="nrol:full">Zenit St Petersburg</name>
-                                        <name part="nprt:common">Zenit St Petersburg</name>
+                                        <name role="nrol:short">Zenit St Petersburg</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -522,7 +522,7 @@
                                 <team id="EFBO782750-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="away">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -565,7 +565,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1368">
                                             <name role="nrol:full">BayArena</name>
-                                            <name part="nprt:common">BayArena</name>
+                                            <name role="nrol:short">BayArena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -579,7 +579,7 @@
                                 <team id="EFBO782773-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="home">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -590,7 +590,7 @@
                                 <team id="EFBO782773-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="away">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -619,7 +619,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2493">
                                             <name role="nrol:full">Petrovski Stadium</name>
-                                            <name part="nprt:common">Petrovski Stadium</name>
+                                            <name role="nrol:short">Petrovski Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -633,7 +633,7 @@
                                 <team id="EFBO782774-TFBB1341">
                                     <team-metadata key="vendteam:TFBB1341" alignment="home">
                                         <name role="nrol:full">Zenit St Petersburg</name>
-                                        <name part="nprt:common">Zenit St Petersburg</name>
+                                        <name role="nrol:short">Zenit St Petersburg</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -647,7 +647,7 @@
                                 <team id="EFBO782774-TFBB251">
                                     <team-metadata key="vendteam:TFBB251" alignment="away">
                                         <name role="nrol:full">Benfica</name>
-                                        <name part="nprt:common">Benfica</name>
+                                        <name role="nrol:short">Benfica</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -673,7 +673,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2713">
                                             <name role="nrol:full">Estádio da Luz</name>
-                                            <name part="nprt:common">Estádio da Luz</name>
+                                            <name role="nrol:short">Estádio da Luz</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -687,7 +687,7 @@
                                 <team id="EFBO782781-TFBB251">
                                     <team-metadata key="vendteam:TFBB251" alignment="home">
                                         <name role="nrol:full">Benfica</name>
-                                        <name part="nprt:common">Benfica</name>
+                                        <name role="nrol:short">Benfica</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -698,7 +698,7 @@
                                 <team id="EFBO782781-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="away">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -715,7 +715,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1313">
                                             <name role="nrol:full">Stade Louis II</name>
-                                            <name part="nprt:common">Stade Louis II</name>
+                                            <name role="nrol:short">Stade Louis II</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -729,7 +729,7 @@
                                 <team id="EFBO782782-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="home">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -746,7 +746,7 @@
                                 <team id="EFBO782782-TFBB1341">
                                     <team-metadata key="vendteam:TFBB1341" alignment="away">
                                         <name role="nrol:full">Zenit St Petersburg</name>
-                                        <name part="nprt:common">Zenit St Petersburg</name>
+                                        <name role="nrol:short">Zenit St Petersburg</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -776,7 +776,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R4" number="4"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782703"
@@ -786,7 +786,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1369">
                                             <name role="nrol:full">Signal Iduna Park</name>
-                                            <name part="nprt:common">Signal Iduna Park</name>
+                                            <name role="nrol:short">Signal Iduna Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -800,7 +800,7 @@
                                 <team id="EFBO782703-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="home">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -817,7 +817,7 @@
                                 <team id="EFBO782703-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="away">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -850,7 +850,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7241">
                                             <name role="nrol:full">Türk Telekom Arena</name>
-                                            <name part="nprt:common">Türk Telekom Arena</name>
+                                            <name role="nrol:short">Türk Telekom Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -864,7 +864,7 @@
                                 <team id="EFBO782704-TFBB208">
                                     <team-metadata key="vendteam:TFBB208" alignment="home">
                                         <name role="nrol:full">Galatasaray</name>
-                                        <name part="nprt:common">Galatasaray</name>
+                                        <name role="nrol:short">Galatasaray</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -878,7 +878,7 @@
                                 <team id="EFBO782704-TFBB241">
                                     <team-metadata key="vendteam:TFBB241" alignment="away">
                                         <name role="nrol:full">RSC Anderlecht</name>
-                                        <name part="nprt:common">RSC Anderlecht</name>
+                                        <name role="nrol:short">RSC Anderlecht</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -914,7 +914,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3250">
                                             <name role="nrol:full">Emirates Stadium</name>
-                                            <name part="nprt:common">Emirates Stadium</name>
+                                            <name role="nrol:short">Emirates Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -928,7 +928,7 @@
                                 <team id="EFBO782727-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="home">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -945,7 +945,7 @@
                                 <team id="EFBO782727-TFBB208">
                                     <team-metadata key="vendteam:TFBB208" alignment="away">
                                         <name role="nrol:full">Galatasaray</name>
-                                        <name part="nprt:common">Galatasaray</name>
+                                        <name role="nrol:short">Galatasaray</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -998,7 +998,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2113">
                                             <name role="nrol:full">Constant Vanden Stockstadion</name>
-                                            <name part="nprt:common">Constant Vanden Stockstadion</name>
+                                            <name role="nrol:short">Constant Vanden Stockstadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1012,7 +1012,7 @@
                                 <team id="EFBO782728-TFBB241">
                                     <team-metadata key="vendteam:TFBB241" alignment="home">
                                         <name role="nrol:full">RSC Anderlecht</name>
-                                        <name part="nprt:common">RSC Anderlecht</name>
+                                        <name role="nrol:short">RSC Anderlecht</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -1023,7 +1023,7 @@
                                 <team id="EFBO782728-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="away">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1069,7 +1069,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7241">
                                             <name role="nrol:full">Türk Telekom Arena</name>
-                                            <name part="nprt:common">Türk Telekom Arena</name>
+                                            <name role="nrol:short">Türk Telekom Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1083,7 +1083,7 @@
                                 <team id="EFBO782743-TFBB208">
                                     <team-metadata key="vendteam:TFBB208" alignment="home">
                                         <name role="nrol:full">Galatasaray</name>
-                                        <name part="nprt:common">Galatasaray</name>
+                                        <name role="nrol:short">Galatasaray</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -1094,7 +1094,7 @@
                                 <team id="EFBO782743-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="away">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1150,7 +1150,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2113">
                                             <name role="nrol:full">Constant Vanden Stockstadion</name>
-                                            <name part="nprt:common">Constant Vanden Stockstadion</name>
+                                            <name role="nrol:short">Constant Vanden Stockstadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1164,7 +1164,7 @@
                                 <team id="EFBO782744-TFBB241">
                                     <team-metadata key="vendteam:TFBB241" alignment="home">
                                         <name role="nrol:full">RSC Anderlecht</name>
-                                        <name part="nprt:common">RSC Anderlecht</name>
+                                        <name role="nrol:short">RSC Anderlecht</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -1178,7 +1178,7 @@
                                 <team id="EFBO782744-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="away">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -1222,7 +1222,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3250">
                                             <name role="nrol:full">Emirates Stadium</name>
-                                            <name part="nprt:common">Emirates Stadium</name>
+                                            <name role="nrol:short">Emirates Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1236,7 +1236,7 @@
                                 <team id="EFBO782751-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="home">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="3"
                                         event-outcome="speventoutcome:tie">
@@ -1256,7 +1256,7 @@
                                 <team id="EFBO782751-TFBB241">
                                     <team-metadata key="vendteam:TFBB241" alignment="away">
                                         <name role="nrol:full">RSC Anderlecht</name>
-                                        <name part="nprt:common">RSC Anderlecht</name>
+                                        <name role="nrol:short">RSC Anderlecht</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="3"
                                         event-outcome="speventoutcome:tie">
@@ -1320,7 +1320,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1369">
                                             <name role="nrol:full">Signal Iduna Park</name>
-                                            <name part="nprt:common">Signal Iduna Park</name>
+                                            <name role="nrol:short">Signal Iduna Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1334,7 +1334,7 @@
                                 <team id="EFBO782752-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="home">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -1357,7 +1357,7 @@
                                 <team id="EFBO782752-TFBB208">
                                     <team-metadata key="vendteam:TFBB208" alignment="away">
                                         <name role="nrol:full">Galatasaray</name>
-                                        <name part="nprt:common">Galatasaray</name>
+                                        <name role="nrol:short">Galatasaray</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -1414,7 +1414,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3250">
                                             <name role="nrol:full">Emirates Stadium</name>
-                                            <name part="nprt:common">Emirates Stadium</name>
+                                            <name role="nrol:short">Emirates Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1428,7 +1428,7 @@
                                 <team id="EFBO782775-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="home">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1445,7 +1445,7 @@
                                 <team id="EFBO782775-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="away">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -1476,7 +1476,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2113">
                                             <name role="nrol:full">Constant Vanden Stockstadion</name>
-                                            <name part="nprt:common">Constant Vanden Stockstadion</name>
+                                            <name role="nrol:short">Constant Vanden Stockstadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1490,7 +1490,7 @@
                                 <team id="EFBO782776-TFBB241">
                                     <team-metadata key="vendteam:TFBB241" alignment="home">
                                         <name role="nrol:full">RSC Anderlecht</name>
-                                        <name part="nprt:common">RSC Anderlecht</name>
+                                        <name role="nrol:short">RSC Anderlecht</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1504,7 +1504,7 @@
                                 <team id="EFBO782776-TFBB208">
                                     <team-metadata key="vendteam:TFBB208" alignment="away">
                                         <name role="nrol:full">Galatasaray</name>
-                                        <name part="nprt:common">Galatasaray</name>
+                                        <name role="nrol:short">Galatasaray</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -1537,7 +1537,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1369">
                                             <name role="nrol:full">Signal Iduna Park</name>
-                                            <name part="nprt:common">Signal Iduna Park</name>
+                                            <name role="nrol:short">Signal Iduna Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1551,7 +1551,7 @@
                                 <team id="EFBO782783-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="home">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -1565,7 +1565,7 @@
                                 <team id="EFBO782783-TFBB241">
                                     <team-metadata key="vendteam:TFBB241" alignment="away">
                                         <name role="nrol:full">RSC Anderlecht</name>
-                                        <name part="nprt:common">RSC Anderlecht</name>
+                                        <name role="nrol:short">RSC Anderlecht</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -1601,7 +1601,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7241">
                                             <name role="nrol:full">Türk Telekom Arena</name>
-                                            <name part="nprt:common">Türk Telekom Arena</name>
+                                            <name role="nrol:short">Türk Telekom Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1615,7 +1615,7 @@
                                 <team id="EFBO782784-TFBB208">
                                     <team-metadata key="vendteam:TFBB208" alignment="home">
                                         <name role="nrol:full">Galatasaray</name>
-                                        <name part="nprt:common">Galatasaray</name>
+                                        <name role="nrol:short">Galatasaray</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -1629,7 +1629,7 @@
                                 <team id="EFBO782784-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="away">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -1682,7 +1682,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R1" number="1"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782697"
@@ -1692,7 +1692,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7598">
                                             <name role="nrol:full">Juventus Stadium</name>
-                                            <name part="nprt:common">Juventus Stadium</name>
+                                            <name role="nrol:short">Juventus Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1706,7 +1706,7 @@
                                 <team id="EFBO782697-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1720,7 +1720,7 @@
                                 <team id="EFBO782697-TFBB993">
                                     <team-metadata key="vendteam:TFBB993" alignment="away">
                                         <name role="nrol:full">Malmö FF</name>
-                                        <name part="nprt:common">Malmö FF</name>
+                                        <name role="nrol:short">Malmö FF</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -1753,7 +1753,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3063">
                                             <name role="nrol:full">Georgios Karaiskakis Stadium</name>
-                                            <name part="nprt:common">Georgios Karaiskakis Stadium</name>
+                                            <name role="nrol:short">Georgios Karaiskakis Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1767,7 +1767,7 @@
                                 <team id="EFBO782698-TFBB202">
                                     <team-metadata key="vendteam:TFBB202" alignment="home">
                                         <name role="nrol:full">Olympiakos</name>
-                                        <name part="nprt:common">Olympiakos</name>
+                                        <name role="nrol:short">Olympiakos</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -1787,7 +1787,7 @@
                                 <team id="EFBO782698-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="away">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -1847,7 +1847,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2599">
                                             <name role="nrol:full">Vicente Calderón</name>
-                                            <name part="nprt:common">Vicente Calderón</name>
+                                            <name role="nrol:short">Vicente Calderón</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1861,7 +1861,7 @@
                                 <team id="EFBO782721-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="home">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1875,7 +1875,7 @@
                                 <team id="EFBO782721-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="away">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -1901,7 +1901,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB8829">
                                             <name role="nrol:full">Swedbank Stadion</name>
-                                            <name part="nprt:common">Swedbank Stadion</name>
+                                            <name role="nrol:short">Swedbank Stadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1915,7 +1915,7 @@
                                 <team id="EFBO782722-TFBB993">
                                     <team-metadata key="vendteam:TFBB993" alignment="home">
                                         <name role="nrol:full">Malmö FF</name>
-                                        <name part="nprt:common">Malmö FF</name>
+                                        <name role="nrol:short">Malmö FF</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -1929,7 +1929,7 @@
                                 <team id="EFBO782722-TFBB202">
                                     <team-metadata key="vendteam:TFBB202" alignment="away">
                                         <name role="nrol:full">Olympiakos</name>
-                                        <name part="nprt:common">Olympiakos</name>
+                                        <name role="nrol:short">Olympiakos</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -1962,7 +1962,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2599">
                                             <name role="nrol:full">Vicente Calderón</name>
-                                            <name part="nprt:common">Vicente Calderón</name>
+                                            <name role="nrol:short">Vicente Calderón</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -1976,7 +1976,7 @@
                                 <team id="EFBO782737-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="home">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="5" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2002,7 +2002,7 @@
                                 <team id="EFBO782737-TFBB993">
                                     <team-metadata key="vendteam:TFBB993" alignment="away">
                                         <name role="nrol:full">Malmö FF</name>
-                                        <name part="nprt:common">Malmö FF</name>
+                                        <name role="nrol:short">Malmö FF</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="5"
                                         event-outcome="speventoutcome:loss">
@@ -2056,7 +2056,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3063">
                                             <name role="nrol:full">Georgios Karaiskakis Stadium</name>
-                                            <name part="nprt:common">Georgios Karaiskakis Stadium</name>
+                                            <name role="nrol:short">Georgios Karaiskakis Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2070,7 +2070,7 @@
                                 <team id="EFBO782738-TFBB202">
                                     <team-metadata key="vendteam:TFBB202" alignment="home">
                                         <name role="nrol:full">Olympiakos</name>
-                                        <name part="nprt:common">Olympiakos</name>
+                                        <name role="nrol:short">Olympiakos</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2084,7 +2084,7 @@
                                 <team id="EFBO782738-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="away">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -2110,7 +2110,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7598">
                                             <name role="nrol:full">Juventus Stadium</name>
-                                            <name part="nprt:common">Juventus Stadium</name>
+                                            <name role="nrol:short">Juventus Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2124,7 +2124,7 @@
                                 <team id="EFBO782745-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -2144,7 +2144,7 @@
                                 <team id="EFBO782745-TFBB202">
                                     <team-metadata key="vendteam:TFBB202" alignment="away">
                                         <name role="nrol:full">Olympiakos</name>
-                                        <name part="nprt:common">Olympiakos</name>
+                                        <name role="nrol:short">Olympiakos</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -2204,7 +2204,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB8829">
                                             <name role="nrol:full">Swedbank Stadion</name>
-                                            <name part="nprt:common">Swedbank Stadion</name>
+                                            <name role="nrol:short">Swedbank Stadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2218,7 +2218,7 @@
                                 <team id="EFBO782746-TFBB993">
                                     <team-metadata key="vendteam:TFBB993" alignment="home">
                                         <name role="nrol:full">Malmö FF</name>
-                                        <name part="nprt:common">Malmö FF</name>
+                                        <name role="nrol:short">Malmö FF</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -2229,7 +2229,7 @@
                                 <team id="EFBO782746-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="away">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2268,7 +2268,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2599">
                                             <name role="nrol:full">Vicente Calderón</name>
-                                            <name part="nprt:common">Vicente Calderón</name>
+                                            <name role="nrol:short">Vicente Calderón</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2282,7 +2282,7 @@
                                 <team id="EFBO782769-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="home">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2299,7 +2299,7 @@
                                 <team id="EFBO782769-TFBB202">
                                     <team-metadata key="vendteam:TFBB202" alignment="away">
                                         <name role="nrol:full">Olympiakos</name>
-                                        <name part="nprt:common">Olympiakos</name>
+                                        <name role="nrol:short">Olympiakos</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -2346,7 +2346,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB8829">
                                             <name role="nrol:full">Swedbank Stadion</name>
-                                            <name part="nprt:common">Swedbank Stadion</name>
+                                            <name role="nrol:short">Swedbank Stadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2360,7 +2360,7 @@
                                 <team id="EFBO782770-TFBB993">
                                     <team-metadata key="vendteam:TFBB993" alignment="home">
                                         <name role="nrol:full">Malmö FF</name>
-                                        <name part="nprt:common">Malmö FF</name>
+                                        <name role="nrol:short">Malmö FF</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -2371,7 +2371,7 @@
                                 <team id="EFBO782770-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="away">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2410,7 +2410,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7598">
                                             <name role="nrol:full">Juventus Stadium</name>
-                                            <name part="nprt:common">Juventus Stadium</name>
+                                            <name role="nrol:short">Juventus Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2424,7 +2424,7 @@
                                 <team id="EFBO782777-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -2435,7 +2435,7 @@
                                 <team id="EFBO782777-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="away">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -2452,7 +2452,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3063">
                                             <name role="nrol:full">Georgios Karaiskakis Stadium</name>
-                                            <name part="nprt:common">Georgios Karaiskakis Stadium</name>
+                                            <name role="nrol:short">Georgios Karaiskakis Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2466,7 +2466,7 @@
                                 <team id="EFBO782778-TFBB202">
                                     <team-metadata key="vendteam:TFBB202" alignment="home">
                                         <name role="nrol:full">Olympiakos</name>
-                                        <name part="nprt:common">Olympiakos</name>
+                                        <name role="nrol:short">Olympiakos</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -2489,7 +2489,7 @@
                                 <team id="EFBO782778-TFBB993">
                                     <team-metadata key="vendteam:TFBB993" alignment="away">
                                         <name role="nrol:full">Malmö FF</name>
-                                        <name part="nprt:common">Malmö FF</name>
+                                        <name role="nrol:short">Malmö FF</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -2553,7 +2553,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R2" number="2"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782699"
@@ -2563,7 +2563,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB39">
                                             <name role="nrol:full">Anfield</name>
-                                            <name part="nprt:common">Anfield</name>
+                                            <name role="nrol:short">Anfield</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2577,7 +2577,7 @@
                                 <team id="EFBO782699-TFBB14">
                                     <team-metadata key="vendteam:TFBB14" alignment="home">
                                         <name role="nrol:full">Liverpool</name>
-                                        <name part="nprt:common">Liverpool</name>
+                                        <name role="nrol:short">Liverpool</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -2594,7 +2594,7 @@
                                 <team id="EFBO782699-TFBB6128">
                                     <team-metadata key="vendteam:TFBB6128" alignment="away">
                                         <name role="nrol:full">Ludogorets Razgrad</name>
-                                        <name part="nprt:common">Ludogorets Razgrad</name>
+                                        <name role="nrol:short">Ludogorets Razgrad</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -2635,7 +2635,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1360">
                                             <name role="nrol:full">Santiago Bernabéu</name>
-                                            <name part="nprt:common">Santiago Bernabéu</name>
+                                            <name role="nrol:short">Santiago Bernabéu</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2649,7 +2649,7 @@
                                 <team id="EFBO782700-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="home">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="5" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -2675,7 +2675,7 @@
                                 <team id="EFBO782700-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="away">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="5"
                                         event-outcome="speventoutcome:loss">
@@ -2739,7 +2739,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2208">
                                             <name role="nrol:full">St Jakob-Park</name>
-                                            <name part="nprt:common">St Jakob-Park</name>
+                                            <name role="nrol:short">St Jakob-Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2753,7 +2753,7 @@
                                 <team id="EFBO782723-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="home">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2767,7 +2767,7 @@
                                 <team id="EFBO782723-TFBB14">
                                     <team-metadata key="vendteam:TFBB14" alignment="away">
                                         <name role="nrol:full">Liverpool</name>
-                                        <name part="nprt:common">Liverpool</name>
+                                        <name role="nrol:short">Liverpool</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -2793,7 +2793,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2995">
                                             <name role="nrol:full">Vasil Levski National Stadium</name>
-                                            <name part="nprt:common">Vasil Levski National Stadium</name>
+                                            <name role="nrol:short">Vasil Levski National Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2807,7 +2807,7 @@
                                 <team id="EFBO782724-TFBB6128">
                                     <team-metadata key="vendteam:TFBB6128" alignment="home">
                                         <name role="nrol:full">Ludogorets Razgrad</name>
-                                        <name part="nprt:common">Ludogorets Razgrad</name>
+                                        <name role="nrol:short">Ludogorets Razgrad</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -2821,7 +2821,7 @@
                                 <team id="EFBO782724-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="away">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -2867,7 +2867,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB39">
                                             <name role="nrol:full">Anfield</name>
-                                            <name part="nprt:common">Anfield</name>
+                                            <name role="nrol:short">Anfield</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2881,7 +2881,7 @@
                                 <team id="EFBO782739-TFBB14">
                                     <team-metadata key="vendteam:TFBB14" alignment="home">
                                         <name role="nrol:full">Liverpool</name>
-                                        <name part="nprt:common">Liverpool</name>
+                                        <name role="nrol:short">Liverpool</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -2892,7 +2892,7 @@
                                 <team id="EFBO782739-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="away">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2938,7 +2938,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2995">
                                             <name role="nrol:full">Vasil Levski National Stadium</name>
-                                            <name part="nprt:common">Vasil Levski National Stadium</name>
+                                            <name role="nrol:short">Vasil Levski National Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -2952,7 +2952,7 @@
                                 <team id="EFBO782740-TFBB6128">
                                     <team-metadata key="vendteam:TFBB6128" alignment="home">
                                         <name role="nrol:full">Ludogorets Razgrad</name>
-                                        <name part="nprt:common">Ludogorets Razgrad</name>
+                                        <name role="nrol:short">Ludogorets Razgrad</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -2966,7 +2966,7 @@
                                 <team id="EFBO782740-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="away">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -2992,7 +2992,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2208">
                                             <name role="nrol:full">St Jakob-Park</name>
-                                            <name part="nprt:common">St Jakob-Park</name>
+                                            <name role="nrol:short">St Jakob-Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3006,7 +3006,7 @@
                                 <team id="EFBO782747-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="home">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3029,7 +3029,7 @@
                                 <team id="EFBO782747-TFBB6128">
                                     <team-metadata key="vendteam:TFBB6128" alignment="away">
                                         <name role="nrol:full">Ludogorets Razgrad</name>
-                                        <name part="nprt:common">Ludogorets Razgrad</name>
+                                        <name role="nrol:short">Ludogorets Razgrad</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -3076,7 +3076,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1360">
                                             <name role="nrol:full">Santiago Bernabéu</name>
-                                            <name part="nprt:common">Santiago Bernabéu</name>
+                                            <name role="nrol:short">Santiago Bernabéu</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3090,7 +3090,7 @@
                                 <team id="EFBO782748-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="home">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3104,7 +3104,7 @@
                                 <team id="EFBO782748-TFBB14">
                                     <team-metadata key="vendteam:TFBB14" alignment="away">
                                         <name role="nrol:full">Liverpool</name>
-                                        <name part="nprt:common">Liverpool</name>
+                                        <name role="nrol:short">Liverpool</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -3130,7 +3130,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2208">
                                             <name role="nrol:full">St Jakob-Park</name>
-                                            <name part="nprt:common">St Jakob-Park</name>
+                                            <name role="nrol:short">St Jakob-Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3144,7 +3144,7 @@
                                 <team id="EFBO782771-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="home">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -3155,7 +3155,7 @@
                                 <team id="EFBO782771-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="away">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3184,7 +3184,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2995">
                                             <name role="nrol:full">Vasil Levski National Stadium</name>
-                                            <name part="nprt:common">Vasil Levski National Stadium</name>
+                                            <name role="nrol:short">Vasil Levski National Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3198,7 +3198,7 @@
                                 <team id="EFBO782772-TFBB6128">
                                     <team-metadata key="vendteam:TFBB6128" alignment="home">
                                         <name role="nrol:full">Ludogorets Razgrad</name>
-                                        <name part="nprt:common">Ludogorets Razgrad</name>
+                                        <name role="nrol:short">Ludogorets Razgrad</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -3215,7 +3215,7 @@
                                 <team id="EFBO782772-TFBB14">
                                     <team-metadata key="vendteam:TFBB14" alignment="away">
                                         <name role="nrol:full">Liverpool</name>
-                                        <name part="nprt:common">Liverpool</name>
+                                        <name role="nrol:short">Liverpool</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -3266,7 +3266,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB39">
                                             <name role="nrol:full">Anfield</name>
-                                            <name part="nprt:common">Anfield</name>
+                                            <name role="nrol:short">Anfield</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3280,7 +3280,7 @@
                                 <team id="EFBO782779-TFBB14">
                                     <team-metadata key="vendteam:TFBB14" alignment="home">
                                         <name role="nrol:full">Liverpool</name>
-                                        <name part="nprt:common">Liverpool</name>
+                                        <name role="nrol:short">Liverpool</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -3294,7 +3294,7 @@
                                 <team id="EFBO782779-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="away">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -3329,7 +3329,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1360">
                                             <name role="nrol:full">Santiago Bernabéu</name>
-                                            <name part="nprt:common">Santiago Bernabéu</name>
+                                            <name role="nrol:short">Santiago Bernabéu</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3343,7 +3343,7 @@
                                 <team id="EFBO782780-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="home">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3366,7 +3366,7 @@
                                 <team id="EFBO782780-TFBB6128">
                                     <team-metadata key="vendteam:TFBB6128" alignment="away">
                                         <name role="nrol:full">Ludogorets Razgrad</name>
-                                        <name part="nprt:common">Ludogorets Razgrad</name>
+                                        <name role="nrol:short">Ludogorets Razgrad</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -3410,7 +3410,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R6" number="6"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782707"
@@ -3420,7 +3420,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB112">
                                             <name role="nrol:full">Amsterdam ArenA</name>
-                                            <name part="nprt:common">Amsterdam ArenA</name>
+                                            <name role="nrol:short">Amsterdam ArenA</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3434,7 +3434,7 @@
                                 <team id="EFBO782707-TFBB215">
                                     <team-metadata key="vendteam:TFBB215" alignment="home">
                                         <name role="nrol:full">Ajax</name>
-                                        <name part="nprt:common">Ajax</name>
+                                        <name role="nrol:short">Ajax</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -3448,7 +3448,7 @@
                                 <team id="EFBO782707-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="away">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -3484,7 +3484,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1349">
                                             <name role="nrol:full">Camp Nou</name>
-                                            <name part="nprt:common">Camp Nou</name>
+                                            <name role="nrol:short">Camp Nou</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3498,7 +3498,7 @@
                                 <team id="EFBO782708-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="home">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3512,7 +3512,7 @@
                                 <team id="EFBO782708-TFBB479">
                                     <team-metadata key="vendteam:TFBB479" alignment="away">
                                         <name role="nrol:full">APOEL Nicosia</name>
-                                        <name part="nprt:common">APOEL Nicosia</name>
+                                        <name role="nrol:short">APOEL Nicosia</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -3538,7 +3538,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2861">
                                             <name role="nrol:full">GSP Stadium</name>
-                                            <name part="nprt:common">GSP Stadium</name>
+                                            <name role="nrol:short">GSP Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3552,7 +3552,7 @@
                                 <team id="EFBO782715-TFBB479">
                                     <team-metadata key="vendteam:TFBB479" alignment="home">
                                         <name role="nrol:full">APOEL Nicosia</name>
-                                        <name part="nprt:common">APOEL Nicosia</name>
+                                        <name role="nrol:short">APOEL Nicosia</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -3566,7 +3566,7 @@
                                 <team id="EFBO782715-TFBB215">
                                     <team-metadata key="vendteam:TFBB215" alignment="away">
                                         <name role="nrol:full">Ajax</name>
-                                        <name part="nprt:common">Ajax</name>
+                                        <name role="nrol:short">Ajax</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -3602,7 +3602,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1311">
                                             <name role="nrol:full">Parc des Princes</name>
-                                            <name part="nprt:common">Parc des Princes</name>
+                                            <name role="nrol:short">Parc des Princes</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3616,7 +3616,7 @@
                                 <team id="EFBO782716-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="home">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -3636,7 +3636,7 @@
                                 <team id="EFBO782716-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -3696,7 +3696,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2861">
                                             <name role="nrol:full">GSP Stadium</name>
-                                            <name part="nprt:common">GSP Stadium</name>
+                                            <name role="nrol:short">GSP Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3710,7 +3710,7 @@
                                 <team id="EFBO782731-TFBB479">
                                     <team-metadata key="vendteam:TFBB479" alignment="home">
                                         <name role="nrol:full">APOEL Nicosia</name>
-                                        <name part="nprt:common">APOEL Nicosia</name>
+                                        <name role="nrol:short">APOEL Nicosia</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -3721,7 +3721,7 @@
                                 <team id="EFBO782731-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="away">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3750,7 +3750,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1349">
                                             <name role="nrol:full">Camp Nou</name>
-                                            <name part="nprt:common">Camp Nou</name>
+                                            <name role="nrol:short">Camp Nou</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3764,7 +3764,7 @@
                                 <team id="EFBO782732-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="home">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -3784,7 +3784,7 @@
                                 <team id="EFBO782732-TFBB215">
                                     <team-metadata key="vendteam:TFBB215" alignment="away">
                                         <name role="nrol:full">Ajax</name>
-                                        <name part="nprt:common">Ajax</name>
+                                        <name role="nrol:short">Ajax</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -3834,7 +3834,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB112">
                                             <name role="nrol:full">Amsterdam ArenA</name>
-                                            <name part="nprt:common">Amsterdam ArenA</name>
+                                            <name role="nrol:short">Amsterdam ArenA</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3848,7 +3848,7 @@
                                 <team id="EFBO782755-TFBB215">
                                     <team-metadata key="vendteam:TFBB215" alignment="home">
                                         <name role="nrol:full">Ajax</name>
-                                        <name part="nprt:common">Ajax</name>
+                                        <name role="nrol:short">Ajax</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -3859,7 +3859,7 @@
                                 <team id="EFBO782755-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3895,7 +3895,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1311">
                                             <name role="nrol:full">Parc des Princes</name>
-                                            <name part="nprt:common">Parc des Princes</name>
+                                            <name role="nrol:short">Parc des Princes</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3909,7 +3909,7 @@
                                 <team id="EFBO782756-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="home">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -3923,7 +3923,7 @@
                                 <team id="EFBO782756-TFBB479">
                                     <team-metadata key="vendteam:TFBB479" alignment="away">
                                         <name role="nrol:full">APOEL Nicosia</name>
-                                        <name part="nprt:common">APOEL Nicosia</name>
+                                        <name role="nrol:short">APOEL Nicosia</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -3949,7 +3949,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2861">
                                             <name role="nrol:full">GSP Stadium</name>
-                                            <name part="nprt:common">GSP Stadium</name>
+                                            <name role="nrol:short">GSP Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -3963,7 +3963,7 @@
                                 <team id="EFBO782763-TFBB479">
                                     <team-metadata key="vendteam:TFBB479" alignment="home">
                                         <name role="nrol:full">APOEL Nicosia</name>
-                                        <name part="nprt:common">APOEL Nicosia</name>
+                                        <name role="nrol:short">APOEL Nicosia</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -3974,7 +3974,7 @@
                                 <team id="EFBO782763-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4027,7 +4027,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1311">
                                             <name role="nrol:full">Parc des Princes</name>
-                                            <name part="nprt:common">Parc des Princes</name>
+                                            <name role="nrol:short">Parc des Princes</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4041,7 +4041,7 @@
                                 <team id="EFBO782764-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="home">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -4058,7 +4058,7 @@
                                 <team id="EFBO782764-TFBB215">
                                     <team-metadata key="vendteam:TFBB215" alignment="away">
                                         <name role="nrol:full">Ajax</name>
-                                        <name part="nprt:common">Ajax</name>
+                                        <name role="nrol:short">Ajax</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -4108,7 +4108,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB112">
                                             <name role="nrol:full">Amsterdam ArenA</name>
-                                            <name part="nprt:common">Amsterdam ArenA</name>
+                                            <name role="nrol:short">Amsterdam ArenA</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4122,7 +4122,7 @@
                                 <team id="EFBO782787-TFBB215">
                                     <team-metadata key="vendteam:TFBB215" alignment="home">
                                         <name role="nrol:full">Ajax</name>
-                                        <name part="nprt:common">Ajax</name>
+                                        <name role="nrol:short">Ajax</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4142,7 +4142,7 @@
                                 <team id="EFBO782787-TFBB479">
                                     <team-metadata key="vendteam:TFBB479" alignment="away">
                                         <name role="nrol:full">APOEL Nicosia</name>
-                                        <name part="nprt:common">APOEL Nicosia</name>
+                                        <name role="nrol:short">APOEL Nicosia</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -4189,7 +4189,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1349">
                                             <name role="nrol:full">Camp Nou</name>
-                                            <name part="nprt:common">Camp Nou</name>
+                                            <name role="nrol:short">Camp Nou</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4203,7 +4203,7 @@
                                 <team id="EFBO782788-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="home">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -4223,7 +4223,7 @@
                                 <team id="EFBO782788-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="away">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -4270,7 +4270,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R8" number="8"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782711"
@@ -4280,7 +4280,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB8973">
                                             <name role="nrol:full">San Mamés</name>
-                                            <name part="nprt:common">San Mamés</name>
+                                            <name role="nrol:short">San Mamés</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4294,7 +4294,7 @@
                                 <team id="EFBO782711-TFBB174">
                                     <team-metadata key="vendteam:TFBB174" alignment="home">
                                         <name role="nrol:full">Athletic Club</name>
-                                        <name part="nprt:common">Athletic Club</name>
+                                        <name role="nrol:short">Athletic Club</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -4305,7 +4305,7 @@
                                 <team id="EFBO782711-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="away">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -4322,7 +4322,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2710">
                                             <name role="nrol:full">Estadio do Dragão</name>
-                                            <name part="nprt:common">Estadio do Dragão</name>
+                                            <name role="nrol:short">Estadio do Dragão</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4336,7 +4336,7 @@
                                 <team id="EFBO782712-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="home">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="6" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4359,7 +4359,7 @@
                                 <team id="EFBO782712-TFBB2155">
                                     <team-metadata key="vendteam:TFBB2155" alignment="away">
                                         <name role="nrol:full">BATE Borisov</name>
-                                        <name part="nprt:common">BATE Borisov</name>
+                                        <name role="nrol:short">BATE Borisov</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="6"
                                         event-outcome="speventoutcome:loss">
@@ -4420,7 +4420,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB9764">
                                             <name role="nrol:full">Borisov Arena</name>
-                                            <name part="nprt:common">Borisov Arena</name>
+                                            <name role="nrol:short">Borisov Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4434,7 +4434,7 @@
                                 <team id="EFBO782719-TFBB2155">
                                     <team-metadata key="vendteam:TFBB2155" alignment="home">
                                         <name role="nrol:full">BATE Borisov</name>
-                                        <name part="nprt:common">BATE Borisov</name>
+                                        <name role="nrol:short">BATE Borisov</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -4451,7 +4451,7 @@
                                 <team id="EFBO782719-TFBB174">
                                     <team-metadata key="vendteam:TFBB174" alignment="away">
                                         <name role="nrol:full">Athletic Club</name>
-                                        <name part="nprt:common">Athletic Club</name>
+                                        <name role="nrol:short">Athletic Club</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -4494,7 +4494,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7761">
                                             <name role="nrol:full">Arena Lviv</name>
-                                            <name part="nprt:common">Arena Lviv</name>
+                                            <name role="nrol:short">Arena Lviv</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4508,7 +4508,7 @@
                                 <team id="EFBO782720-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="home">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -4525,7 +4525,7 @@
                                 <team id="EFBO782720-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="away">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -4575,7 +4575,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB9764">
                                             <name role="nrol:full">Borisov Arena</name>
-                                            <name part="nprt:common">Borisov Arena</name>
+                                            <name role="nrol:short">Borisov Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4589,7 +4589,7 @@
                                 <team id="EFBO782735-TFBB2155">
                                     <team-metadata key="vendteam:TFBB2155" alignment="home">
                                         <name role="nrol:full">BATE Borisov</name>
-                                        <name part="nprt:common">BATE Borisov</name>
+                                        <name role="nrol:short">BATE Borisov</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="7"
                                         event-outcome="speventoutcome:loss">
@@ -4600,7 +4600,7 @@
                                 <team id="EFBO782735-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="away">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="7" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4677,7 +4677,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2710">
                                             <name role="nrol:full">Estadio do Dragão</name>
-                                            <name part="nprt:common">Estadio do Dragão</name>
+                                            <name role="nrol:short">Estadio do Dragão</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4691,7 +4691,7 @@
                                 <team id="EFBO782736-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="home">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -4708,7 +4708,7 @@
                                 <team id="EFBO782736-TFBB174">
                                     <team-metadata key="vendteam:TFBB174" alignment="away">
                                         <name role="nrol:full">Athletic Club</name>
-                                        <name part="nprt:common">Athletic Club</name>
+                                        <name role="nrol:short">Athletic Club</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -4751,7 +4751,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB8973">
                                             <name role="nrol:full">San Mamés</name>
-                                            <name part="nprt:common">San Mamés</name>
+                                            <name role="nrol:short">San Mamés</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4765,7 +4765,7 @@
                                 <team id="EFBO782759-TFBB174">
                                     <team-metadata key="vendteam:TFBB174" alignment="home">
                                         <name role="nrol:full">Athletic Club</name>
-                                        <name part="nprt:common">Athletic Club</name>
+                                        <name role="nrol:short">Athletic Club</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -4776,7 +4776,7 @@
                                 <team id="EFBO782759-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="away">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4815,7 +4815,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7761">
                                             <name role="nrol:full">Arena Lviv</name>
-                                            <name part="nprt:common">Arena Lviv</name>
+                                            <name role="nrol:short">Arena Lviv</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4829,7 +4829,7 @@
                                 <team id="EFBO782760-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="home">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="5" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4849,7 +4849,7 @@
                                 <team id="EFBO782760-TFBB2155">
                                     <team-metadata key="vendteam:TFBB2155" alignment="away">
                                         <name role="nrol:full">BATE Borisov</name>
-                                        <name part="nprt:common">BATE Borisov</name>
+                                        <name role="nrol:short">BATE Borisov</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="5"
                                         event-outcome="speventoutcome:loss">
@@ -4903,7 +4903,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB9764">
                                             <name role="nrol:full">Borisov Arena</name>
-                                            <name part="nprt:common">Borisov Arena</name>
+                                            <name role="nrol:short">Borisov Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4917,7 +4917,7 @@
                                 <team id="EFBO782767-TFBB2155">
                                     <team-metadata key="vendteam:TFBB2155" alignment="home">
                                         <name role="nrol:full">BATE Borisov</name>
-                                        <name part="nprt:common">BATE Borisov</name>
+                                        <name role="nrol:short">BATE Borisov</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -4928,7 +4928,7 @@
                                 <team id="EFBO782767-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="away">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -4977,7 +4977,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7761">
                                             <name role="nrol:full">Arena Lviv</name>
-                                            <name part="nprt:common">Arena Lviv</name>
+                                            <name role="nrol:short">Arena Lviv</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -4991,7 +4991,7 @@
                                 <team id="EFBO782768-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="home">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -5002,7 +5002,7 @@
                                 <team id="EFBO782768-TFBB174">
                                     <team-metadata key="vendteam:TFBB174" alignment="away">
                                         <name role="nrol:full">Athletic Club</name>
-                                        <name part="nprt:common">Athletic Club</name>
+                                        <name role="nrol:short">Athletic Club</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -5031,7 +5031,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB8973">
                                             <name role="nrol:full">San Mamés</name>
-                                            <name part="nprt:common">San Mamés</name>
+                                            <name role="nrol:short">San Mamés</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5045,7 +5045,7 @@
                                 <team id="EFBO782791-TFBB174">
                                     <team-metadata key="vendteam:TFBB174" alignment="home">
                                         <name role="nrol:full">Athletic Club</name>
-                                        <name part="nprt:common">Athletic Club</name>
+                                        <name role="nrol:short">Athletic Club</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -5062,7 +5062,7 @@
                                 <team id="EFBO782791-TFBB2155">
                                     <team-metadata key="vendteam:TFBB2155" alignment="away">
                                         <name role="nrol:full">BATE Borisov</name>
-                                        <name part="nprt:common">BATE Borisov</name>
+                                        <name role="nrol:short">BATE Borisov</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -5095,7 +5095,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2710">
                                             <name role="nrol:full">Estadio do Dragão</name>
-                                            <name part="nprt:common">Estadio do Dragão</name>
+                                            <name role="nrol:short">Estadio do Dragão</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5109,7 +5109,7 @@
                                 <team id="EFBO782792-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="home">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5123,7 +5123,7 @@
                                 <team id="EFBO782792-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="away">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5156,7 +5156,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R7" number="7"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782709"
@@ -5166,7 +5166,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB35">
                                             <name role="nrol:full">Stamford Bridge</name>
-                                            <name part="nprt:common">Stamford Bridge</name>
+                                            <name role="nrol:short">Stamford Bridge</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5180,7 +5180,7 @@
                                 <team id="EFBO782709-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="home">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5194,7 +5194,7 @@
                                 <team id="EFBO782709-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="away">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5229,7 +5229,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3328">
                                             <name role="nrol:full">Ljudski vrt</name>
-                                            <name part="nprt:common">Ljudski vrt</name>
+                                            <name role="nrol:short">Ljudski vrt</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5243,7 +5243,7 @@
                                 <team id="EFBO782710-TFBB3033">
                                     <team-metadata key="vendteam:TFBB3033" alignment="home">
                                         <name role="nrol:full">NK Maribor</name>
-                                        <name part="nprt:common">NK Maribor</name>
+                                        <name role="nrol:short">NK Maribor</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5257,7 +5257,7 @@
                                 <team id="EFBO782710-TFBB255">
                                     <team-metadata key="vendteam:TFBB255" alignment="away">
                                         <name role="nrol:full">Sporting Lisbon</name>
-                                        <name part="nprt:common">Sporting Lisbon</name>
+                                        <name role="nrol:short">Sporting Lisbon</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5293,7 +5293,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2095">
                                             <name role="nrol:full">VELTINS-Arena</name>
-                                            <name part="nprt:common">VELTINS-Arena</name>
+                                            <name role="nrol:short">VELTINS-Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5307,7 +5307,7 @@
                                 <team id="EFBO782717-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="home">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5321,7 +5321,7 @@
                                 <team id="EFBO782717-TFBB3033">
                                     <team-metadata key="vendteam:TFBB3033" alignment="away">
                                         <name role="nrol:full">NK Maribor</name>
-                                        <name part="nprt:common">NK Maribor</name>
+                                        <name role="nrol:short">NK Maribor</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5357,7 +5357,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2116">
                                             <name role="nrol:full">Estadio José Alvalade</name>
-                                            <name part="nprt:common">Estadio José Alvalade</name>
+                                            <name role="nrol:short">Estadio José Alvalade</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5371,7 +5371,7 @@
                                 <team id="EFBO782718-TFBB255">
                                     <team-metadata key="vendteam:TFBB255" alignment="home">
                                         <name role="nrol:full">Sporting Lisbon</name>
-                                        <name part="nprt:common">Sporting Lisbon</name>
+                                        <name role="nrol:short">Sporting Lisbon</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -5382,7 +5382,7 @@
                                 <team id="EFBO782718-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="away">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -5410,7 +5410,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB35">
                                             <name role="nrol:full">Stamford Bridge</name>
-                                            <name part="nprt:common">Stamford Bridge</name>
+                                            <name role="nrol:short">Stamford Bridge</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5424,7 +5424,7 @@
                                 <team id="EFBO782733-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="home">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="6" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -5450,7 +5450,7 @@
                                 <team id="EFBO782733-TFBB3033">
                                     <team-metadata key="vendteam:TFBB3033" alignment="away">
                                         <name role="nrol:full">NK Maribor</name>
-                                        <name part="nprt:common">NK Maribor</name>
+                                        <name role="nrol:short">NK Maribor</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="6"
                                         event-outcome="speventoutcome:loss">
@@ -5506,7 +5506,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2095">
                                             <name role="nrol:full">VELTINS-Arena</name>
-                                            <name part="nprt:common">VELTINS-Arena</name>
+                                            <name role="nrol:short">VELTINS-Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5520,7 +5520,7 @@
                                 <team id="EFBO782734-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="home">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="3"
                                         event-outcome="speventoutcome:win">
@@ -5543,7 +5543,7 @@
                                 <team id="EFBO782734-TFBB255">
                                     <team-metadata key="vendteam:TFBB255" alignment="away">
                                         <name role="nrol:full">Sporting Lisbon</name>
-                                        <name part="nprt:common">Sporting Lisbon</name>
+                                        <name role="nrol:short">Sporting Lisbon</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -5617,7 +5617,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3328">
                                             <name role="nrol:full">Ljudski vrt</name>
-                                            <name part="nprt:common">Ljudski vrt</name>
+                                            <name role="nrol:short">Ljudski vrt</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5631,7 +5631,7 @@
                                 <team id="EFBO782757-TFBB3033">
                                     <team-metadata key="vendteam:TFBB3033" alignment="home">
                                         <name role="nrol:full">NK Maribor</name>
-                                        <name part="nprt:common">NK Maribor</name>
+                                        <name role="nrol:short">NK Maribor</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5645,7 +5645,7 @@
                                 <team id="EFBO782757-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="away">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -5680,7 +5680,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2116">
                                             <name role="nrol:full">Estadio José Alvalade</name>
-                                            <name part="nprt:common">Estadio José Alvalade</name>
+                                            <name role="nrol:short">Estadio José Alvalade</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5694,7 +5694,7 @@
                                 <team id="EFBO782758-TFBB255">
                                     <team-metadata key="vendteam:TFBB255" alignment="home">
                                         <name role="nrol:full">Sporting Lisbon</name>
-                                        <name part="nprt:common">Sporting Lisbon</name>
+                                        <name role="nrol:short">Sporting Lisbon</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -5717,7 +5717,7 @@
                                 <team id="EFBO782758-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="away">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -5781,7 +5781,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2095">
                                             <name role="nrol:full">VELTINS-Arena</name>
-                                            <name part="nprt:common">VELTINS-Arena</name>
+                                            <name role="nrol:short">VELTINS-Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5795,7 +5795,7 @@
                                 <team id="EFBO782765-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="home">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="5"
                                         event-outcome="speventoutcome:loss">
@@ -5806,7 +5806,7 @@
                                 <team id="EFBO782765-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="away">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="5" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -5871,7 +5871,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2116">
                                             <name role="nrol:full">Estadio José Alvalade</name>
-                                            <name part="nprt:common">Estadio José Alvalade</name>
+                                            <name role="nrol:short">Estadio José Alvalade</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5885,7 +5885,7 @@
                                 <team id="EFBO782766-TFBB255">
                                     <team-metadata key="vendteam:TFBB255" alignment="home">
                                         <name role="nrol:full">Sporting Lisbon</name>
-                                        <name part="nprt:common">Sporting Lisbon</name>
+                                        <name role="nrol:short">Sporting Lisbon</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -5905,7 +5905,7 @@
                                 <team id="EFBO782766-TFBB3033">
                                     <team-metadata key="vendteam:TFBB3033" alignment="away">
                                         <name role="nrol:full">NK Maribor</name>
-                                        <name part="nprt:common">NK Maribor</name>
+                                        <name role="nrol:short">NK Maribor</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -5955,7 +5955,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB35">
                                             <name role="nrol:full">Stamford Bridge</name>
-                                            <name part="nprt:common">Stamford Bridge</name>
+                                            <name role="nrol:short">Stamford Bridge</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -5969,7 +5969,7 @@
                                 <team id="EFBO782789-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="home">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -5989,7 +5989,7 @@
                                 <team id="EFBO782789-TFBB255">
                                     <team-metadata key="vendteam:TFBB255" alignment="away">
                                         <name role="nrol:full">Sporting Lisbon</name>
-                                        <name part="nprt:common">Sporting Lisbon</name>
+                                        <name role="nrol:short">Sporting Lisbon</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -6036,7 +6036,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3328">
                                             <name role="nrol:full">Ljudski vrt</name>
-                                            <name part="nprt:common">Ljudski vrt</name>
+                                            <name role="nrol:short">Ljudski vrt</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6050,7 +6050,7 @@
                                 <team id="EFBO782790-TFBB3033">
                                     <team-metadata key="vendteam:TFBB3033" alignment="home">
                                         <name role="nrol:full">NK Maribor</name>
-                                        <name part="nprt:common">NK Maribor</name>
+                                        <name role="nrol:short">NK Maribor</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -6061,7 +6061,7 @@
                                 <team id="EFBO782790-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="away">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -6087,7 +6087,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S1R5" number="5"
                                 format-type="sptournamentform:single-group" maximum-subparts="12" minimum-subparts="12">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO782705"
@@ -6097,7 +6097,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2775">
                                             <name role="nrol:full">Allianz Arena</name>
-                                            <name part="nprt:common">Allianz Arena</name>
+                                            <name role="nrol:short">Allianz Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6111,7 +6111,7 @@
                                 <team id="EFBO782705-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="home">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -6125,7 +6125,7 @@
                                 <team id="EFBO782705-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="away">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -6151,7 +6151,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1336">
                                             <name role="nrol:full">Olimpico</name>
-                                            <name part="nprt:common">Olimpico</name>
+                                            <name role="nrol:short">Olimpico</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6165,7 +6165,7 @@
                                 <team id="EFBO782706-TFBB121">
                                     <team-metadata key="vendteam:TFBB121" alignment="home">
                                         <name role="nrol:full">Roma</name>
-                                        <name part="nprt:common">Roma</name>
+                                        <name role="nrol:short">Roma</name>
                                     </team-metadata>
                                     <team-stats score="5" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -6188,7 +6188,7 @@
                                 <team id="EFBO782706-TFBB1340">
                                     <team-metadata key="vendteam:TFBB1340" alignment="away">
                                         <name role="nrol:full">CSKA Moscow</name>
-                                        <name part="nprt:common">CSKA Moscow</name>
+                                        <name role="nrol:short">CSKA Moscow</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="5"
                                         event-outcome="speventoutcome:loss">
@@ -6252,7 +6252,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB5047">
                                             <name role="nrol:full">Arena Khimki</name>
-                                            <name part="nprt:common">Arena Khimki</name>
+                                            <name role="nrol:short">Arena Khimki</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6266,7 +6266,7 @@
                                 <team id="EFBO782713-TFBB1340">
                                     <team-metadata key="vendteam:TFBB1340" alignment="home">
                                         <name role="nrol:full">CSKA Moscow</name>
-                                        <name part="nprt:common">CSKA Moscow</name>
+                                        <name role="nrol:short">CSKA Moscow</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -6277,7 +6277,7 @@
                                 <team id="EFBO782713-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="away">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -6306,7 +6306,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2691">
                                             <name role="nrol:full">Etihad Stadium</name>
-                                            <name part="nprt:common">Etihad Stadium</name>
+                                            <name role="nrol:short">Etihad Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6320,7 +6320,7 @@
                                 <team id="EFBO782714-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="home">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -6334,7 +6334,7 @@
                                 <team id="EFBO782714-TFBB121">
                                     <team-metadata key="vendteam:TFBB121" alignment="away">
                                         <name role="nrol:full">Roma</name>
-                                        <name part="nprt:common">Roma</name>
+                                        <name role="nrol:short">Roma</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -6369,7 +6369,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB5047">
                                             <name role="nrol:full">Arena Khimki</name>
-                                            <name part="nprt:common">Arena Khimki</name>
+                                            <name role="nrol:short">Arena Khimki</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6383,7 +6383,7 @@
                                 <team id="EFBO782729-TFBB1340">
                                     <team-metadata key="vendteam:TFBB1340" alignment="home">
                                         <name role="nrol:full">CSKA Moscow</name>
-                                        <name part="nprt:common">CSKA Moscow</name>
+                                        <name role="nrol:short">CSKA Moscow</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -6400,7 +6400,7 @@
                                 <team id="EFBO782729-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="away">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -6451,7 +6451,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1336">
                                             <name role="nrol:full">Olimpico</name>
-                                            <name part="nprt:common">Olimpico</name>
+                                            <name role="nrol:short">Olimpico</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6465,7 +6465,7 @@
                                 <team id="EFBO782730-TFBB121">
                                     <team-metadata key="vendteam:TFBB121" alignment="home">
                                         <name role="nrol:full">Roma</name>
-                                        <name part="nprt:common">Roma</name>
+                                        <name role="nrol:short">Roma</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="7"
                                         event-outcome="speventoutcome:loss">
@@ -6479,7 +6479,7 @@
                                 <team id="EFBO782730-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="away">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="7" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -6572,7 +6572,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2775">
                                             <name role="nrol:full">Allianz Arena</name>
-                                            <name part="nprt:common">Allianz Arena</name>
+                                            <name role="nrol:short">Allianz Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6586,7 +6586,7 @@
                                 <team id="EFBO782753-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="home">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -6603,7 +6603,7 @@
                                 <team id="EFBO782753-TFBB121">
                                     <team-metadata key="vendteam:TFBB121" alignment="away">
                                         <name role="nrol:full">Roma</name>
-                                        <name part="nprt:common">Roma</name>
+                                        <name role="nrol:short">Roma</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -6636,7 +6636,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2691">
                                             <name role="nrol:full">Etihad Stadium</name>
-                                            <name part="nprt:common">Etihad Stadium</name>
+                                            <name role="nrol:short">Etihad Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6650,7 +6650,7 @@
                                 <team id="EFBO782754-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="home">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -6664,7 +6664,7 @@
                                 <team id="EFBO782754-TFBB1340">
                                     <team-metadata key="vendteam:TFBB1340" alignment="away">
                                         <name role="nrol:full">CSKA Moscow</name>
-                                        <name part="nprt:common">CSKA Moscow</name>
+                                        <name role="nrol:short">CSKA Moscow</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -6706,7 +6706,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB5047">
                                             <name role="nrol:full">Arena Khimki</name>
-                                            <name part="nprt:common">Arena Khimki</name>
+                                            <name role="nrol:short">Arena Khimki</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6720,7 +6720,7 @@
                                 <team id="EFBO782761-TFBB1340">
                                     <team-metadata key="vendteam:TFBB1340" alignment="home">
                                         <name role="nrol:full">CSKA Moscow</name>
-                                        <name part="nprt:common">CSKA Moscow</name>
+                                        <name role="nrol:short">CSKA Moscow</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -6734,7 +6734,7 @@
                                 <team id="EFBO782761-TFBB121">
                                     <team-metadata key="vendteam:TFBB121" alignment="away">
                                         <name role="nrol:full">Roma</name>
-                                        <name part="nprt:common">Roma</name>
+                                        <name role="nrol:short">Roma</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -6770,7 +6770,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2691">
                                             <name role="nrol:full">Etihad Stadium</name>
-                                            <name part="nprt:common">Etihad Stadium</name>
+                                            <name role="nrol:short">Etihad Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6784,7 +6784,7 @@
                                 <team id="EFBO782762-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="home">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -6798,7 +6798,7 @@
                                 <team id="EFBO782762-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="away">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -6855,7 +6855,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2775">
                                             <name role="nrol:full">Allianz Arena</name>
-                                            <name part="nprt:common">Allianz Arena</name>
+                                            <name role="nrol:short">Allianz Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6869,7 +6869,7 @@
                                 <team id="EFBO782785-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="home">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -6889,7 +6889,7 @@
                                 <team id="EFBO782785-TFBB1340">
                                     <team-metadata key="vendteam:TFBB1340" alignment="away">
                                         <name role="nrol:full">CSKA Moscow</name>
-                                        <name part="nprt:common">CSKA Moscow</name>
+                                        <name role="nrol:short">CSKA Moscow</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -6929,7 +6929,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1336">
                                             <name role="nrol:full">Olimpico</name>
-                                            <name part="nprt:common">Olimpico</name>
+                                            <name role="nrol:short">Olimpico</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -6943,7 +6943,7 @@
                                 <team id="EFBO782786-TFBB121">
                                     <team-metadata key="vendteam:TFBB121" alignment="home">
                                         <name role="nrol:full">Roma</name>
-                                        <name part="nprt:common">Roma</name>
+                                        <name role="nrol:short">Roma</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -6954,7 +6954,7 @@
                                 <team id="EFBO782786-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="away">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -6989,13 +6989,13 @@
                         <tournament-part-metadata key="vendkey:CFBB52014S2" type="sptournamentphase:elimination"
                             number="2" maximum-subparts="4" minimum-subparts="4">
                             <name role="nrol:full">Champions League</name>
-                            <name part="nprt:common">Champions League</name>
+                            <name role="nrol:short">Champions League</name>
                         </tournament-part-metadata>
                         <tournament-part>
                             <tournament-part-metadata key="vendkey:CFBB52014S2R1" number="1"
                                 format-type="sptournamentform:home-and-home" maximum-subparts="16" minimum-subparts="16">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO788097"
@@ -7010,7 +7010,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1311">
                                             <name role="nrol:full">Parc des Princes</name>
-                                            <name part="nprt:common">Parc des Princes</name>
+                                            <name role="nrol:short">Parc des Princes</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7024,7 +7024,7 @@
                                 <team id="EFBO788097-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="home">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -7038,7 +7038,7 @@
                                 <team id="EFBO788097-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="away">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -7078,7 +7078,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7761">
                                             <name role="nrol:full">Arena Lviv</name>
-                                            <name part="nprt:common">Arena Lviv</name>
+                                            <name role="nrol:short">Arena Lviv</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7092,7 +7092,7 @@
                                 <team id="EFBO788103-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="home">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -7103,7 +7103,7 @@
                                 <team id="EFBO788103-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="away">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -7125,7 +7125,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2208">
                                             <name role="nrol:full">St Jakob-Park</name>
-                                            <name part="nprt:common">St Jakob-Park</name>
+                                            <name role="nrol:short">St Jakob-Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7139,7 +7139,7 @@
                                 <team id="EFBO788105-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="home">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -7153,7 +7153,7 @@
                                 <team id="EFBO788105-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="away">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -7194,7 +7194,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2095">
                                             <name role="nrol:full">VELTINS-Arena</name>
-                                            <name part="nprt:common">VELTINS-Arena</name>
+                                            <name role="nrol:short">VELTINS-Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7208,7 +7208,7 @@
                                 <team id="EFBO788102-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="home">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -7219,7 +7219,7 @@
                                 <team id="EFBO788102-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="away">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -7263,7 +7263,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7598">
                                             <name role="nrol:full">Juventus Stadium</name>
-                                            <name part="nprt:common">Juventus Stadium</name>
+                                            <name role="nrol:short">Juventus Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7277,7 +7277,7 @@
                                 <team id="EFBO788101-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -7294,7 +7294,7 @@
                                 <team id="EFBO788101-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="away">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -7342,7 +7342,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2691">
                                             <name role="nrol:full">Etihad Stadium</name>
-                                            <name part="nprt:common">Etihad Stadium</name>
+                                            <name role="nrol:short">Etihad Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7356,7 +7356,7 @@
                                 <team id="EFBO788099-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="home">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -7370,7 +7370,7 @@
                                 <team id="EFBO788099-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -7417,7 +7417,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB3250">
                                             <name role="nrol:full">Emirates Stadium</name>
-                                            <name part="nprt:common">Emirates Stadium</name>
+                                            <name role="nrol:short">Emirates Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7431,7 +7431,7 @@
                                 <team id="EFBO788104-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="home">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -7445,7 +7445,7 @@
                                 <team id="EFBO788104-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="away">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -7505,7 +7505,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1368">
                                             <name role="nrol:full">BayArena</name>
-                                            <name part="nprt:common">BayArena</name>
+                                            <name role="nrol:short">BayArena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7519,7 +7519,7 @@
                                 <team id="EFBO788100-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="home">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -7533,7 +7533,7 @@
                                 <team id="EFBO788100-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="away">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -7565,7 +7565,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2710">
                                             <name role="nrol:full">Estadio do Dragão</name>
-                                            <name part="nprt:common">Estadio do Dragão</name>
+                                            <name role="nrol:short">Estadio do Dragão</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7579,7 +7579,7 @@
                                 <team id="EFBO788113-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="home">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -7608,7 +7608,7 @@
                                 <team id="EFBO788113-TFBB481">
                                     <team-metadata key="vendteam:TFBB481" alignment="away">
                                         <name role="nrol:full">FC Basel</name>
-                                        <name part="nprt:common">FC Basel</name>
+                                        <name role="nrol:short">FC Basel</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -7668,7 +7668,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1360">
                                             <name role="nrol:full">Santiago Bernabéu</name>
-                                            <name part="nprt:common">Santiago Bernabéu</name>
+                                            <name role="nrol:short">Santiago Bernabéu</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7682,7 +7682,7 @@
                                 <team id="EFBO788110-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="home">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="4"
                                         event-outcome="speventoutcome:loss">
@@ -7705,7 +7705,7 @@
                                 <team id="EFBO788110-TFBB167">
                                     <team-metadata key="vendteam:TFBB167" alignment="away">
                                         <name role="nrol:full">FC Schalke 04</name>
-                                        <name part="nprt:common">FC Schalke 04</name>
+                                        <name role="nrol:short">FC Schalke 04</name>
                                     </team-metadata>
                                     <team-stats score="4" score-opposing="3"
                                         event-outcome="speventoutcome:win">
@@ -7793,7 +7793,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB35">
                                             <name role="nrol:full">Stamford Bridge</name>
-                                            <name part="nprt:common">Stamford Bridge</name>
+                                            <name role="nrol:short">Stamford Bridge</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7807,7 +7807,7 @@
                                 <team id="EFBO788106-TFBB8">
                                     <team-metadata key="vendteam:TFBB8" alignment="home">
                                         <name role="nrol:full">Chelsea</name>
-                                        <name part="nprt:common">Chelsea</name>
+                                        <name role="nrol:short">Chelsea</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -7833,7 +7833,7 @@
                                 <team id="EFBO788106-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="away">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="2"
                                         event-outcome="speventoutcome:tie">
@@ -7900,7 +7900,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2775">
                                             <name role="nrol:full">Allianz Arena</name>
-                                            <name part="nprt:common">Allianz Arena</name>
+                                            <name role="nrol:short">Allianz Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -7914,7 +7914,7 @@
                                 <team id="EFBO788111-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="home">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="7" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -7949,7 +7949,7 @@
                                 <team id="EFBO788111-TFBB455">
                                     <team-metadata key="vendteam:TFBB455" alignment="away">
                                         <name role="nrol:full">Shakhtar Donetsk</name>
-                                        <name part="nprt:common">Shakhtar Donetsk</name>
+                                        <name role="nrol:short">Shakhtar Donetsk</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="7"
                                         event-outcome="speventoutcome:loss">
@@ -8030,7 +8030,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2599">
                                             <name role="nrol:full">Vicente Calderón</name>
-                                            <name part="nprt:common">Vicente Calderón</name>
+                                            <name role="nrol:short">Vicente Calderón</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8044,7 +8044,7 @@
                                 <team id="EFBO788108-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="home">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8076,7 +8076,7 @@
                                 <team id="EFBO788108-TFBB164">
                                     <team-metadata key="vendteam:TFBB164" alignment="away">
                                         <name role="nrol:full">Bayer 04 Leverkusen</name>
-                                        <name part="nprt:common">Bayer 04 Leverkusen</name>
+                                        <name role="nrol:short">Bayer 04 Leverkusen</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -8161,7 +8161,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1313">
                                             <name role="nrol:full">Stade Louis II</name>
-                                            <name part="nprt:common">Stade Louis II</name>
+                                            <name role="nrol:short">Stade Louis II</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8175,7 +8175,7 @@
                                 <team id="EFBO788112-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="home">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -8192,7 +8192,7 @@
                                 <team id="EFBO788112-TFBB3">
                                     <team-metadata key="vendteam:TFBB3" alignment="away">
                                         <name role="nrol:full">Arsenal</name>
-                                        <name part="nprt:common">Arsenal</name>
+                                        <name role="nrol:short">Arsenal</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8241,7 +8241,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1349">
                                             <name role="nrol:full">Camp Nou</name>
-                                            <name part="nprt:common">Camp Nou</name>
+                                            <name role="nrol:short">Camp Nou</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8255,7 +8255,7 @@
                                 <team id="EFBO788107-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="home">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8275,7 +8275,7 @@
                                 <team id="EFBO788107-TFBB43">
                                     <team-metadata key="vendteam:TFBB43" alignment="away">
                                         <name role="nrol:full">Manchester City</name>
-                                        <name part="nprt:common">Manchester City</name>
+                                        <name role="nrol:short">Manchester City</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -8313,7 +8313,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1369">
                                             <name role="nrol:full">Signal Iduna Park</name>
-                                            <name part="nprt:common">Signal Iduna Park</name>
+                                            <name role="nrol:short">Signal Iduna Park</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8327,7 +8327,7 @@
                                 <team id="EFBO788109-TFBB157">
                                     <team-metadata key="vendteam:TFBB157" alignment="home">
                                         <name role="nrol:full">Borussia Dortmund</name>
-                                        <name part="nprt:common">Borussia Dortmund</name>
+                                        <name role="nrol:short">Borussia Dortmund</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -8344,7 +8344,7 @@
                                 <team id="EFBO788109-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="away">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8393,7 +8393,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S2R2" number="2"
                                 format-type="sptournamentform:home-and-home" maximum-subparts="8" minimum-subparts="8">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO799715"
@@ -8408,7 +8408,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2599">
                                             <name role="nrol:full">Vicente Calderón</name>
-                                            <name part="nprt:common">Vicente Calderón</name>
+                                            <name role="nrol:short">Vicente Calderón</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8422,7 +8422,7 @@
                                 <team id="EFBO799715-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="home">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -8433,7 +8433,7 @@
                                 <team id="EFBO799715-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="away">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -8455,7 +8455,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7598">
                                             <name role="nrol:full">Juventus Stadium</name>
-                                            <name part="nprt:common">Juventus Stadium</name>
+                                            <name role="nrol:short">Juventus Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8469,7 +8469,7 @@
                                 <team id="EFBO799713-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8483,7 +8483,7 @@
                                 <team id="EFBO799713-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="away">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -8514,7 +8514,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2710">
                                             <name role="nrol:full">Estadio do Dragão</name>
-                                            <name part="nprt:common">Estadio do Dragão</name>
+                                            <name role="nrol:short">Estadio do Dragão</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8528,7 +8528,7 @@
                                 <team id="EFBO799720-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="home">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -8545,7 +8545,7 @@
                                 <team id="EFBO799720-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="away">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -8600,7 +8600,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1311">
                                             <name role="nrol:full">Parc des Princes</name>
-                                            <name part="nprt:common">Parc des Princes</name>
+                                            <name role="nrol:short">Parc des Princes</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8614,7 +8614,7 @@
                                 <team id="EFBO799717-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="home">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -8628,7 +8628,7 @@
                                 <team id="EFBO799717-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -8687,7 +8687,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1349">
                                             <name role="nrol:full">Camp Nou</name>
-                                            <name part="nprt:common">Camp Nou</name>
+                                            <name role="nrol:short">Camp Nou</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8701,7 +8701,7 @@
                                 <team id="EFBO799718-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="home">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8721,7 +8721,7 @@
                                 <team id="EFBO799718-TFBB149">
                                     <team-metadata key="vendteam:TFBB149" alignment="away">
                                         <name role="nrol:full">Paris Saint-Germain</name>
-                                        <name part="nprt:common">Paris Saint-Germain</name>
+                                        <name role="nrol:short">Paris Saint-Germain</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -8767,7 +8767,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2775">
                                             <name role="nrol:full">Allianz Arena</name>
-                                            <name part="nprt:common">Allianz Arena</name>
+                                            <name role="nrol:short">Allianz Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8781,7 +8781,7 @@
                                 <team id="EFBO799723-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="home">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="6" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -8813,7 +8813,7 @@
                                 <team id="EFBO799723-TFBB201">
                                     <team-metadata key="vendteam:TFBB201" alignment="away">
                                         <name role="nrol:full">FC Porto</name>
-                                        <name part="nprt:common">FC Porto</name>
+                                        <name role="nrol:short">FC Porto</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="6"
                                         event-outcome="speventoutcome:loss">
@@ -8896,7 +8896,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1313">
                                             <name role="nrol:full">Stade Louis II</name>
-                                            <name part="nprt:common">Stade Louis II</name>
+                                            <name role="nrol:short">Stade Louis II</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8910,7 +8910,7 @@
                                 <team id="EFBO799714-TFBB146">
                                     <team-metadata key="vendteam:TFBB146" alignment="home">
                                         <name role="nrol:full">Monaco</name>
-                                        <name part="nprt:common">Monaco</name>
+                                        <name role="nrol:short">Monaco</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -8927,7 +8927,7 @@
                                 <team id="EFBO799714-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="away">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="0"
                                         event-outcome="speventoutcome:tie">
@@ -8957,7 +8957,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1360">
                                             <name role="nrol:full">Santiago Bernabéu</name>
-                                            <name part="nprt:common">Santiago Bernabéu</name>
+                                            <name role="nrol:short">Santiago Bernabéu</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -8971,7 +8971,7 @@
                                 <team id="EFBO799716-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="home">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -8991,7 +8991,7 @@
                                 <team id="EFBO799716-TFBB175">
                                     <team-metadata key="vendteam:TFBB175" alignment="away">
                                         <name role="nrol:full">Atlético de Madrid</name>
-                                        <name part="nprt:common">Atlético de Madrid</name>
+                                        <name role="nrol:short">Atlético de Madrid</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="1"
                                         event-outcome="speventoutcome:loss">
@@ -9020,7 +9020,7 @@
                             <tournament-part-metadata key="vendkey:CFBB52014S2R3" number="3"
                                 format-type="sptournamentform:home-and-home" maximum-subparts="4" minimum-subparts="4">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO800858"
@@ -9035,7 +9035,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB7598">
                                             <name role="nrol:full">Juventus Stadium</name>
-                                            <name part="nprt:common">Juventus Stadium</name>
+                                            <name role="nrol:short">Juventus Stadium</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -9049,7 +9049,7 @@
                                 <team id="EFBO800858-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="1"
                                         event-outcome="speventoutcome:win">
@@ -9066,7 +9066,7 @@
                                 <team id="EFBO800858-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="away">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="2"
                                         event-outcome="speventoutcome:loss">
@@ -9114,7 +9114,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1349">
                                             <name role="nrol:full">Camp Nou</name>
-                                            <name part="nprt:common">Camp Nou</name>
+                                            <name role="nrol:short">Camp Nou</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -9128,7 +9128,7 @@
                                 <team id="EFBO800857-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="home">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="0"
                                         event-outcome="speventoutcome:win">
@@ -9145,7 +9145,7 @@
                                 <team id="EFBO800857-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="away">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="0" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -9191,7 +9191,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB2775">
                                             <name role="nrol:full">Allianz Arena</name>
-                                            <name part="nprt:common">Allianz Arena</name>
+                                            <name role="nrol:short">Allianz Arena</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -9205,7 +9205,7 @@
                                 <team id="EFBO800859-TFBB156">
                                     <team-metadata key="vendteam:TFBB156" alignment="home">
                                         <name role="nrol:full">FC Bayern München</name>
-                                        <name part="nprt:common">FC Bayern München</name>
+                                        <name role="nrol:short">FC Bayern München</name>
                                     </team-metadata>
                                     <team-stats score="3" score-opposing="2"
                                         event-outcome="speventoutcome:win">
@@ -9231,7 +9231,7 @@
                                 <team id="EFBO800859-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                     <team-stats score="2" score-opposing="3"
                                         event-outcome="speventoutcome:loss">
@@ -9300,7 +9300,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1360">
                                             <name role="nrol:full">Santiago Bernabéu</name>
-                                            <name part="nprt:common">Santiago Bernabéu</name>
+                                            <name role="nrol:short">Santiago Bernabéu</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -9314,7 +9314,7 @@
                                 <team id="EFBO800860-TFBB186">
                                     <team-metadata key="vendteam:TFBB186" alignment="home">
                                         <name role="nrol:full">Real Madrid</name>
-                                        <name part="nprt:common">Real Madrid</name>
+                                        <name role="nrol:short">Real Madrid</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -9334,7 +9334,7 @@
                                 <team id="EFBO800860-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="away">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                     <team-stats score="1" score-opposing="1"
                                         event-outcome="speventoutcome:tie">
@@ -9374,7 +9374,7 @@
                                 format-type="sptournamentform:single-elimination" maximum-subparts="1"
                                 minimum-subparts="1">
                                 <name role="nrol:full">Champions League</name>
-                                <name part="nprt:common">Champions League</name>
+                                <name role="nrol:short">Champions League</name>
                             </tournament-part-metadata>
                             <sports-event>
                                 <event-metadata key="vendevent:EFBO800865"
@@ -9385,7 +9385,7 @@
                                     <site>
                                         <site-metadata key="vendsite:VFBB1375">
                                             <name role="nrol:full">Olympiastadion</name>
-                                            <name part="nprt:common">Olympiastadion</name>
+                                            <name role="nrol:short">Olympiastadion</name>
                                             <home-location>
                                                 <POIDetails>
                                                   <address/>
@@ -9399,13 +9399,13 @@
                                 <team id="EFBO800865-TFBB128">
                                     <team-metadata key="vendteam:TFBB128" alignment="home">
                                         <name role="nrol:full">Juventus</name>
-                                        <name part="nprt:common">Juventus</name>
+                                        <name role="nrol:short">Juventus</name>
                                     </team-metadata>
                                 </team>
                                 <team id="EFBO800865-TFBB178">
                                     <team-metadata key="vendteam:TFBB178" alignment="away">
                                         <name role="nrol:full">Barcelona</name>
-                                        <name part="nprt:common">Barcelona</name>
+                                        <name role="nrol:short">Barcelona</name>
                                     </team-metadata>
                                 </team>
                             </sports-event>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SportsML is an open and highly flexible standard for the interchange of sports d
 
 The IPTC [Developer Site](http://dev.iptc.org/SportsML) provides technical information.
 
-The [SportsML Users Forum](https://groups.yahoo.com/neo/groups/sportsml/info) is used to share experiences, raise questions and recommend and discuss changes to the SportsML standard. It also connects companies and organizations who use SportsML and vendors who create tools that process NewsML-G2 documents. 
+The [SportsML Users Forum](https://groups.io/g/iptc-sportsml) is used to share experiences, raise questions and recommend and discuss changes to the SportsML standard. It also connects companies and organizations who use SportsML and vendors who create tools that process NewsML-G2 documents. 
 
 ### Specification
 
@@ -31,10 +31,11 @@ The complete documentation in html-format. Open sportsml.html in your browser.
 More information can be found in the [NewsML-G2 Guidelines](https://www.iptc.org/std/NewsML-G2/latest/IPTC-G2-Implementation_Guide).
 
 ###
-Download version 3.0.3 [here](https://github.com/iptc/sportsml-3/archive/v3.0.3.zip).
+Download version 3.0.4 [here](https://github.com/iptc/sportsml-3/archive/v3.0.4.zip).
 
 ### Revision history
 
+* 3.0.4 Examples corrected to use valid NewsCodes for name part and name role (January 2019)
 * 3.0.3 Errata correction in schema and tools added.
 * 3.0.2 IPTC approved version in June 2016.
 * 3.0.1 Official draft version.


### PR DESCRIPTION
Also updates README to call this release 3.0.4.

The spec doesn't change, so the standard is still simply SportsML 3.0.